### PR TITLE
fix: adjust time suggestion to be bigger than

### DIFF
--- a/src/components/time-entry-form.tsx
+++ b/src/components/time-entry-form.tsx
@@ -121,10 +121,10 @@ export default function TimeEntryForm({ entry, selectedDate, onSave, onClose, us
       const travelTimeInMinutes = (travelTimeValue || 0) * 60;
       const totalActivityInMinutes = workDurationInMinutes + travelTimeInMinutes;
 
-      if (totalActivityInMinutes >= 9 * 60) {
+      if (totalActivityInMinutes > 9 * 60) {
         return { minutes: 45, timeString: '00:45', reason: '9 hours' };
       }
-      if (totalActivityInMinutes >= 6 * 60) {
+      if (totalActivityInMinutes > 6 * 60) {
         return { minutes: 30, timeString: '00:30', reason: '6 hours' };
       }
       return null;


### PR DESCRIPTION
This pull request includes a minor adjustment to the `TimeEntryForm` component to refine the logic for calculating break times based on total activity duration.

### Logic refinement:
* [`src/components/time-entry-form.tsx`](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbL124-R127): Updated the conditional checks for total activity duration to use `>` instead of `>=` when determining break times for 6 and 9 hours of activity. This ensures that the break time is only applied when the total activity strictly exceeds the threshold.