### PR TITLE
feat: add autobump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,4 +24,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output new version
-        run: echo "New version is ${{ steps.bump_version.outputs.newTag }}" 
+        run: echo "New version is ${{ steps.bump_version.outputs.newTag }}"

--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ This project includes a complete CI/CD pipeline configured with GitHub Actions. 
       4.  Push the version bump to `package.json`.
   - **Conventional Commits**: This workflow relies on commit messages following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification (e.g., `feat: ...`, `fix: ...`).
 
+- **`version-bump.yml` (Automatic Version Bumping)**:
+  - **Trigger**: Runs when a pull request is merged into the `main` branch.
+  - **Jobs**:
+    - Bumps the project version and creates a new tag based on PR title keywords (`#major`, `#minor`, `#patch`).
+    - Uses [`phips28/gh-action-bump-version`](https://github.com/marketplace/actions/github-tag-bump) to determine the version bump type.
+  - **Purpose**: Ensures that every merge to `main` results in a version bump and tag, following the PR's intent.
+
 - **`deploy.yml` (Continuous Deployment)**:
   - **Trigger**: Runs automatically whenever a new GitHub Release is `published`.
   - **Jobs**:


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automatically bump the version number when a pull request is merged into the `main` branch. This ensures that versioning is consistently updated without manual intervention.

### New GitHub Actions Workflow:

* [`.github/workflows/version-bump.yml`](diffhunk://#diff-e8ca070981ccdc3f369851c960bec6882143a0c7afe78acd7b05e0c2b0068d72R1-R27): Added a new workflow named `Bump version on PR merge`. The workflow triggers when a pull request is closed and merged into the `main` branch. It uses the `phips28/gh-action-bump-version` action to increment the version number, push the new tag, and output the updated version.