### PR TITLE
fix: use tel type on mobile for pause duration field

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -27,3 +27,19 @@ jest.mock('@/context/i18n-context', () => ({
     loading: false,
   }),
 }))
+
+// Add this at the very top of your test file or in jest.setup.ts
+if (!window.matchMedia) {
+  window.matchMedia = function () {
+    return {
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(), // deprecated
+      removeListener: jest.fn(), // deprecated
+      dispatchEvent: jest.fn(),
+    }
+  }
+}

--- a/src/lib/i18n/dictionaries.ts
+++ b/src/lib/i18n/dictionaries.ts
@@ -95,6 +95,11 @@ export const dictionaries = {
       endTimeLabel: 'End time',
       optionalDetailsTitle: 'Optional Details',
       pauseLabel: 'Pause',
+      pauseDurationLabel: 'Pause Duration (HH:mm)',
+      pauseDurationDescription:
+        'Enter the total duration of your pause in HH:mm format (e.g. {example} for 30 minutes).',
+      pauseDurationInvalid:
+        'Please enter a valid duration in HH:mm format (e.g. {example}).',
       pauseSuggestion: 'Suggest: {minutes} min',
       pauseSuggestionTooltip:
         'Activity over {hours}. Recommended pause: {minutes} mins.',
@@ -298,7 +303,12 @@ export const dictionaries = {
         'Diese Aktion kann nicht rückgängig gemacht werden. Der Zeiteintrag für "{location}" wird dauerhaft gelöscht.',
       deleteAlertCancel: 'Abbrechen',
       deleteAlertConfirm: 'Löschen',
-      pauseLabel: '{minutes} Min. Pause',
+      pauseLabel: 'Pause',
+      pauseDurationLabel: 'Pausendauer (HH:mm)',
+      pauseDurationDescription:
+        'Geben Sie die Gesamtdauer Ihrer Pause im Format HH:mm ein (z.B. {example} für 30 Minuten).',
+      pauseDurationInvalid:
+        'Bitte geben Sie eine gültige Dauer im Format HH:mm ein (z.B. {example}).',
       travelLabel: '{hours} Std. Fahrt',
       driverLabel: 'Fahrer',
       runningLabel: 'Jetzt',
@@ -318,6 +328,11 @@ export const dictionaries = {
       endTimeLabel: 'Endzeit',
       optionalDetailsTitle: 'Optionale Angaben',
       pauseLabel: 'Pause',
+      pauseDurationLabel: 'Pause Duration (HH:mm)',
+      pauseDurationDescription:
+        'Enter the total duration of your pause in HH:mm format (e.g. {example} for 30 minutes).',
+      pauseDurationInvalid:
+        'Please enter a valid duration in HH:mm format (e.g. {example}).',
       pauseSuggestion: 'Vorschlag: {minutes} Min.',
       pauseSuggestionTooltip:
         'Aktivität über {hours}. Empfohlene Pause: {minutes} Min.',


### PR DESCRIPTION
This pull request introduces functionality to handle pause durations in the time entry form, with enhancements for mobile users and improved internationalization support. Key changes include adding mobile-specific behavior, input validation for pause duration, and new translations for related labels and descriptions.

### Mobile-Specific Enhancements:
* [`src/components/time-entry-form.tsx`](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR321-R337): Introduced a mobile-friendly input for pause duration that uses `type="tel"`, formats input as `HH:mm`, and validates the duration. Added helper functions `formatDurationInput` and `isValidDuration` for input handling. [[1]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR321-R337) [[2]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbL476-R530)
* [`jest.setup.ts`](diffhunk://#diff-a1c786cdea90125d840669112d499d337a658bf6431a8c972a2e14301d908662R30-R45): Mocked the `window.matchMedia` function to support mobile-specific tests.
* [`src/components/__tests__/time-entry-form.test.tsx`](diffhunk://#diff-313671db3bbf57b32eff5fa176f9cfdb2cf86404502d0df1073582be36ba9070R31-R36): Mocked the `useIsMobile` hook and added tests to verify mobile-specific behavior, including input formatting and placeholder validation. [[1]](diffhunk://#diff-313671db3bbf57b32eff5fa176f9cfdb2cf86404502d0df1073582be36ba9070R31-R36) [[2]](diffhunk://#diff-313671db3bbf57b32eff5fa176f9cfdb2cf86404502d0df1073582be36ba9070R308-R385)

### Internationalization Updates:
* [`src/lib/i18n/dictionaries.ts`](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R98-R102): Added new translations for pause duration labels, descriptions, and error messages in multiple languages. [[1]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R98-R102) [[2]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34L301-R311) [[3]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R331-R335)

### Code Integration:
* [`src/components/time-entry-form.tsx`](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR52): Imported and utilized the `useIsMobile` hook to conditionally render mobile-specific input fields. [[1]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR52) [[2]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR126)