### PR TITLE
feat: enable duration-only entries

### DIFF
--- a/e2e/test-helpers.ts
+++ b/e2e/test-helpers.ts
@@ -18,3 +18,22 @@ export const addManualEntry = async (
   await form.getByRole('button', { name: 'Eintrag speichern' }).click()
   await expect(form).not.toBeVisible()
 }
+
+// Helper function to create a new duration-only entry for the currently selected day
+export const addDurationEntry = async (
+  page: Page,
+  location: string,
+  duration: number, // in minutes
+) => {
+  await page.getByRole('button', { name: 'Hinzufügen' }).click()
+  const form = page.locator(
+    'div[role="dialog"]:has(h2:has-text("Zeiteintrag hinzufügen"))',
+  )
+  await expect(form).toBeVisible()
+  await form.getByLabel('Einsatzort').fill(location)
+  // Switch to duration mode (Radix Switch)
+  await form.getByTestId('mode-switch').click()
+  await form.getByLabel('Dauer (Minuten)').fill(duration.toString())
+  await form.getByRole('button', { name: 'Eintrag speichern' }).click()
+  await expect(form).not.toBeVisible()
+}

--- a/e2e/tracker.spec.ts
+++ b/e2e/tracker.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-import { addManualEntry } from './test-helpers'
+import { addDurationEntry, addManualEntry } from './test-helpers'
 
 test.describe('Core Tracker Functionality', () => {
   // --- SETUP: Run before each test in this file ---
@@ -302,6 +302,22 @@ test.describe('Core Tracker Functionality', () => {
       await expect(form.getByText(/Warnung/i)).toBeVisible()
       await form.getByRole('button', { name: 'Eintrag speichern' }).click()
     })
+
+    test('should add, display, and delete a duration-only entry', async ({
+      page,
+    }) => {
+      const location = 'Duration Only E2E'
+      const duration = 90 // 1h 30m
+      await addDurationEntry(page, location, duration)
+      const entryCard = page.locator(`[data-location="${location}"]`)
+      await expect(entryCard).toBeVisible()
+      await expect(entryCard.getByText(/Dauer: 90 min/)).toBeVisible()
+      await expect(entryCard.getByText('01:30:00')).toBeVisible()
+      // Delete
+      await entryCard.getByRole('button', { name: 'Löschen' }).click()
+      await page.getByRole('button', { name: 'Löschen', exact: true }).click()
+      await expect(entryCard).not.toBeVisible()
+    })
   })
 
   // --- DAILY ACTIONS & SPECIAL ENTRIES ---
@@ -327,9 +343,9 @@ test.describe('Core Tracker Functionality', () => {
       )
       await expect(form).toBeVisible()
       // A special entry's start/end times can be changed.
-      await form.getByLabel('Startzeit').fill('10:00') // Originally 09:00 - 16:00 (7h)
+      await form.getByLabel('Dauer (Minuten)').fill('360') // Originally 7h
       await form.getByRole('button', { name: 'Eintrag speichern' }).click()
-      await expect(sickCard.getByText('06:00:00')).toBeVisible() // Now 10:00 - 16:00 (6h)
+      await expect(sickCard.getByText('06:00:00')).toBeVisible() // Now 6h
 
       // Delete
       await sickCard.getByRole('button', { name: 'Löschen' }).click()

--- a/src/components/__tests__/time-entry-card.test.tsx
+++ b/src/components/__tests__/time-entry-card.test.tsx
@@ -71,6 +71,59 @@ describe('TimeEntryCard', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('renders a duration-only entry correctly', () => {
+    const durationEntry: TimeEntry = {
+      id: '2',
+      userId: 'user-1',
+      location: 'Duration Task',
+      durationMinutes: 150, // 2h 30m
+      startTime: new Date('2024-01-10T12:00:00'),
+      pauseDuration: 0,
+      travelTime: 0,
+      isDriver: false,
+    }
+    render(
+      <TimeEntryCard
+        entry={durationEntry}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    )
+
+    expect(screen.getByText('Duration Task')).toBeInTheDocument()
+    expect(screen.getByText(/time_entry_form.durationLabel: 150 min/)).toBeInTheDocument()
+    expect(screen.getByText('02:30:00')).toBeInTheDocument()
+    // Should not show a time range
+    expect(screen.queryByText(/-.*:/)).not.toBeInTheDocument()
+  })
+
+  it('allows creating and displaying a duration-only entry', () => {
+    // Simulate creating a duration-only entry and rendering it
+    const newDurationEntry: TimeEntry = {
+      id: '3',
+      userId: 'user-2',
+      location: 'Duration Only',
+      durationMinutes: 90, // 1h 30m
+      startTime: new Date('2024-01-10T12:00:00'),
+      pauseDuration: 0,
+      travelTime: 0,
+      isDriver: false,
+    }
+    render(
+      <TimeEntryCard
+        entry={newDurationEntry}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    )
+
+    expect(screen.getByText('Duration Only')).toBeInTheDocument()
+    expect(screen.getByText(/time_entry_form.durationLabel: 90 min/)).toBeInTheDocument()
+    expect(screen.getByText('01:30:00')).toBeInTheDocument()
+    // Should not show a time range
+    expect(screen.queryByText(/-.*:/)).not.toBeInTheDocument()
+  })
+
   it('calls onEdit when the edit button is clicked', () => {
     render(
       <TimeEntryCard entry={baseEntry} onEdit={onEdit} onDelete={onDelete} />,

--- a/src/components/__tests__/time-entry-card.test.tsx
+++ b/src/components/__tests__/time-entry-card.test.tsx
@@ -91,7 +91,9 @@ describe('TimeEntryCard', () => {
     )
 
     expect(screen.getByText('Duration Task')).toBeInTheDocument()
-    expect(screen.getByText(/time_entry_form.durationLabel: 150 min/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/time_entry_form.durationLabel: 150 min/),
+    ).toBeInTheDocument()
     expect(screen.getByText('02:30:00')).toBeInTheDocument()
     // Should not show a time range
     expect(screen.queryByText(/-.*:/)).not.toBeInTheDocument()
@@ -118,7 +120,9 @@ describe('TimeEntryCard', () => {
     )
 
     expect(screen.getByText('Duration Only')).toBeInTheDocument()
-    expect(screen.getByText(/time_entry_form.durationLabel: 90 min/)).toBeInTheDocument()
+    expect(
+      screen.getByText(/time_entry_form.durationLabel: 90 min/),
+    ).toBeInTheDocument()
     expect(screen.getByText('01:30:00')).toBeInTheDocument()
     // Should not show a time range
     expect(screen.queryByText(/-.*:/)).not.toBeInTheDocument()

--- a/src/components/time-entry-card.tsx
+++ b/src/components/time-entry-card.tsx
@@ -69,15 +69,18 @@ export default function TimeEntryCard({
   }
 
   const calculateCompensatedSeconds = () => {
+    if (typeof entry.durationMinutes === 'number') {
+      return entry.durationMinutes * 60
+    }
     if (!entry.endTime) {
-      // Handle running timer case
+      if (!entry.startTime) return 0
       return (new Date().getTime() - entry.startTime.getTime()) / 1000
     }
 
-    const workDurationInMinutes = differenceInMinutes(
-      entry.endTime,
-      entry.startTime,
-    )
+    const workDurationInMinutes =
+      entry.startTime && entry.endTime
+        ? differenceInMinutes(entry.endTime, entry.startTime)
+        : entry.durationMinutes || 0
 
     if (isSpecial) {
       // For special entries, the duration is just the time between start and end.
@@ -93,6 +96,10 @@ export default function TimeEntryCard({
   }
 
   const totalCompensatedSeconds = calculateCompensatedSeconds()
+
+  const formattedStartTime = format(entry.startTime, 'p')
+  const formattedEndTime =
+    entry.endTime instanceof Date ? format(entry.endTime, 'p') : ''
 
   if (SpecialIcon) {
     return (
@@ -176,15 +183,22 @@ export default function TimeEntryCard({
           <div className="grid flex-1 gap-1">
             <p className="font-semibold">{entry.location}</p>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
-              <div className="flex items-center">
-                <Clock className="mr-1.5 h-3.5 w-3.5" />
-                <span>
-                  {format(entry.startTime, 'p')} -{' '}
-                  {entry.endTime
-                    ? format(entry.endTime, 'p')
-                    : t('time_entry_card.runningLabel')}
-                </span>
-              </div>
+              {typeof entry.durationMinutes === 'number' ? (
+                <div className="flex items-center">
+                  <Clock className="mr-1.5 h-3.5 w-3.5" />
+                  <span>
+                    {t('time_entry_form.durationLabel')}:{' '}
+                    {entry.durationMinutes} min
+                  </span>
+                </div>
+              ) : (
+                <div className="flex items-center">
+                  <Clock className="mr-1.5 h-3.5 w-3.5" />
+                  <span>
+                    {formattedStartTime} - {formattedEndTime}
+                  </span>
+                </div>
+              )}
               {entry.pauseDuration && entry.pauseDuration > 0 ? (
                 <div className="flex items-center">
                   <Coffee className="mr-1.5 h-3.5 w-3.5" />

--- a/src/components/timesheet-preview.tsx
+++ b/src/components/timesheet-preview.tsx
@@ -226,10 +226,16 @@ export default function TimesheetPreview({
 
                   return dayEntries.map((entry, entryIndex) => {
                     let compensatedHours = 0
-                    if (entry.endTime) {
+                    let fromValue = ''
+                    let toValue = ''
+                    if (typeof entry.durationMinutes === 'number') {
+                      compensatedHours = entry.durationMinutes / 60
+                      fromValue = t('time_entry_form.durationLabel')
+                      toValue = `${entry.durationMinutes} min`
+                    } else if (entry.endTime) {
                       const workDuration = differenceInMinutes(
                         entry.endTime,
-                        entry.startTime,
+                        entry.startTime!,
                       )
                       const isCompensatedSpecialDay = [
                         'SICK_LEAVE',
@@ -246,6 +252,12 @@ export default function TimesheetPreview({
                         compensatedHours =
                           compensatedMinutes > 0 ? compensatedMinutes / 60 : 0
                       }
+                      fromValue = entry.startTime
+                        ? format(entry.startTime, 'HH:mm')
+                        : ''
+                      toValue = entry.endTime
+                        ? format(entry.endTime, 'HH:mm')
+                        : ''
                     }
 
                     return (
@@ -289,21 +301,34 @@ export default function TimesheetPreview({
                           {getLocationDisplayName(entry.location)}
                         </TableCell>
                         <TableCell className="text-right print:p-1">
-                          {entry.startTime
-                            ? format(entry.startTime, 'HH:mm')
-                            : ''}
+                          {/* For duration-only entries, leave blank */}
+                          {typeof entry.durationMinutes === 'number'
+                            ? ''
+                            : fromValue}
                         </TableCell>
                         <TableCell className="text-right print:p-1">
-                          {entry.endTime ? format(entry.endTime, 'HH:mm') : ''}
+                          {/* For duration-only entries, leave blank */}
+                          {typeof entry.durationMinutes === 'number'
+                            ? ''
+                            : toValue}
                         </TableCell>
                         <TableCell className="border-l border-r border-black text-right print:p-1">
-                          {formatDecimalHours(entry.pauseDuration)}
+                          {/* Show blank if pause is 0 or 0.00 */}
+                          {entry.pauseDuration && entry.pauseDuration !== 0
+                            ? formatDecimalHours(entry.pauseDuration)
+                            : ''}
                         </TableCell>
                         <TableCell className="border-r border-black text-right print:p-1">
-                          {(entry.travelTime || 0).toFixed(2)}
+                          {/* Show blank if travel is 0 or 0.00 */}
+                          {entry.travelTime && entry.travelTime !== 0
+                            ? entry.travelTime.toFixed(2)
+                            : ''}
                         </TableCell>
                         <TableCell className="border-r border-black text-right print:p-1">
-                          {compensatedHours.toFixed(2)}
+                          {/* Show blank if compensated is 0 or 0.00 */}
+                          {compensatedHours && compensatedHours !== 0
+                            ? compensatedHours.toFixed(2)
+                            : ''}
                         </TableCell>
                         <TableCell className="border-r border-black text-left print:p-1">
                           {entry.isDriver ? t('export_preview.driverMark') : ''}

--- a/src/context/i18n-context.tsx
+++ b/src/context/i18n-context.tsx
@@ -22,7 +22,7 @@ interface I18nContextType {
   loading: boolean
 }
 
-const TimeWiseIcon = (props: React.SVGProps<SVGSVGElement>) => (
+const LoadingIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
     width="24"
     height="24"
@@ -122,7 +122,7 @@ export const I18nProvider = ({ children }: { children: ReactNode }) => {
     return (
       <div className="flex h-screen items-center justify-center bg-background">
         <div className="flex flex-col items-center space-y-4">
-          <TimeWiseIcon className="h-12 w-12 animate-spin text-primary" />
+          <LoadingIcon className="h-12 w-12 animate-spin text-primary" />
         </div>
       </div>
     )

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,6 +1,9 @@
+import type { TimeEntry } from '../types'
 import {
+  compareEntriesByStartTime,
   formatAppDate,
   formatAppNumber,
+  formatAppTime,
   formatDecimalHours,
   formatDuration,
   formatHoursAndMinutes,
@@ -86,6 +89,79 @@ describe('utils', () => {
     })
     it('should format number with custom options', () => {
       expect(formatAppNumber(0.5, 'en', { style: 'percent' })).toBe('50%')
+    })
+  })
+
+  describe('compareEntriesByStartTime', () => {
+    const now = new Date('2024-01-10T12:00:00')
+    const earlier = new Date('2024-01-09T12:00:00')
+    const later = new Date('2024-01-11T12:00:00')
+
+    const intervalEntry1: TimeEntry = {
+      id: '1',
+      userId: 'u',
+      location: 'A',
+      startTime: now,
+      endTime: later,
+    }
+    const intervalEntry2: TimeEntry = {
+      id: '2',
+      userId: 'u',
+      location: 'B',
+      startTime: earlier,
+      endTime: now,
+    }
+    const durationEntry1: TimeEntry = {
+      id: '3',
+      userId: 'u',
+      location: 'C',
+      startTime: now,
+      durationMinutes: 60,
+    }
+    const durationEntry2: TimeEntry = {
+      id: '4',
+      userId: 'u',
+      location: 'D',
+      startTime: earlier,
+      durationMinutes: 120,
+    }
+
+    it('sorts interval entries by startTime descending', () => {
+      const arr = [intervalEntry2, intervalEntry1]
+      arr.sort(compareEntriesByStartTime)
+      expect(arr[0]).toBe(intervalEntry1)
+      expect(arr[1]).toBe(intervalEntry2)
+    })
+
+    it('puts all duration-only entries after interval entries, even if they have a startTime', () => {
+      const arr = [
+        durationEntry1,
+        intervalEntry1,
+        durationEntry2,
+        intervalEntry2,
+      ]
+      arr.sort(compareEntriesByStartTime)
+      expect(arr.slice(0, 2)).toEqual([intervalEntry1, intervalEntry2])
+      expect(arr.slice(2)).toEqual([durationEntry1, durationEntry2])
+    })
+  })
+
+  describe('formatAppTime', () => {
+    it('formats a typical time correctly', () => {
+      const date = new Date('2024-01-10T09:05:00')
+      expect(formatAppTime(date)).toBe('09:05')
+    })
+    it('formats midnight as 00:00', () => {
+      const date = new Date('2024-01-10T00:00:00')
+      expect(formatAppTime(date)).toBe('00:00')
+    })
+    it('formats single-digit hours and minutes with leading zeros', () => {
+      const date = new Date('2024-01-10T03:07:00')
+      expect(formatAppTime(date)).toBe('03:07')
+    })
+    it('formats 23:59 correctly', () => {
+      const date = new Date('2024-01-10T23:59:00')
+      expect(formatAppTime(date)).toBe('23:59')
     })
   })
 })

--- a/src/lib/excel-export.ts
+++ b/src/lib/excel-export.ts
@@ -242,10 +242,16 @@ export const exportToExcel = async ({
       if (dayEntries.length > 0) {
         dayEntries.forEach((entry) => {
           let compensatedHours = 0
-          if (entry.endTime) {
+          let fromValue = ''
+          let toValue = ''
+          if (typeof entry.durationMinutes === 'number') {
+            compensatedHours = entry.durationMinutes / 60
+            fromValue = ''
+            toValue = ''
+          } else if (entry.endTime) {
             const workDuration = differenceInMinutes(
               entry.endTime,
-              entry.startTime,
+              entry.startTime!,
             )
             const isCompensatedSpecialDay = [
               'SICK_LEAVE',
@@ -262,6 +268,8 @@ export const exportToExcel = async ({
               compensatedHours =
                 compensatedMinutes > 0 ? compensatedMinutes / 60 : 0
             }
+            fromValue = entry.startTime ? format(entry.startTime, 'HH:mm') : ''
+            toValue = entry.endTime ? format(entry.endTime, 'HH:mm') : ''
           }
           const pauseDecimal = parseFloat(
             formatDecimalHours(entry.pauseDuration),
@@ -278,8 +286,8 @@ export const exportToExcel = async ({
             '', // Weekday gets merged
             '', // Date gets merged
             getLocationDisplayName(entry.location),
-            entry.startTime ? format(entry.startTime, 'HH:mm') : '',
-            entry.endTime ? format(entry.endTime, 'HH:mm') : '',
+            fromValue,
+            toValue,
             pauseCellValue,
             travelCellValue,
             compensatedHours,

--- a/src/lib/i18n/dictionaries.ts
+++ b/src/lib/i18n/dictionaries.ts
@@ -130,6 +130,13 @@ export const dictionaries = {
       geolocationNotSupportedToastTitle: 'Geolocation not supported',
       geolocationNotSupportedToastDescription:
         'Your browser does not support geolocation.',
+      entryModeLabel: 'Entry mode',
+      modeInterval: 'By interval',
+      modeDuration: 'By duration',
+      durationLabel: 'Duration',
+      durationFormLabel: 'Duration (minutes)',
+      durationInvalid:
+        'Please enter a valid duration in minutes. Minimum is 5 minutes.',
     },
     // Toasts
     toasts: {
@@ -370,6 +377,13 @@ export const dictionaries = {
       geolocationNotSupportedToastTitle: 'Geolokalisierung nicht unterstützt',
       geolocationNotSupportedToastDescription:
         'Ihr Browser unterstützt keine Geolokalisierung.',
+      entryModeLabel: 'Erfassungsmodus',
+      modeInterval: 'Nach Zeitraum',
+      modeDuration: 'Nach Dauer',
+      durationLabel: 'Dauer',
+      durationFormLabel: 'Dauer (Minuten)',
+      durationInvalid:
+        'Bitte geben Sie eine gültige Dauer in Minuten ein. Mindestdauer ist 5 Minuten.',
     },
     // Toasts
     toasts: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,8 +1,16 @@
+/**
+ * TimeEntry represents a work entry for a user.
+ * - All entries MUST have a startTime (used for date assignment).
+ * - For interval-based entries: use startTime and endTime.
+ * - For duration-only entries: set startTime to the correct date at 12:00 local time (midday), and set durationMinutes.
+ * - endTime is optional for duration-only entries.
+ */
 export interface TimeEntry {
   id: string
   userId: string
-  startTime: Date
-  endTime?: Date // undefined if timer is running
+  startTime: Date // Always required for date assignment (set to midday for duration-only)
+  endTime?: Date // Only for interval-based entries
+  durationMinutes?: number // Only for duration-only entries
   location: string
   pauseDuration?: number // in minutes
   travelTime?: number // in decimal hours

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,6 +10,8 @@ import {
 import { de, enUS } from 'date-fns/locale'
 import { twMerge } from 'tailwind-merge'
 
+import type { TimeEntry } from './types'
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
@@ -111,4 +113,21 @@ export function formatAppNumber(
 export function formatAppTime(date: Date) {
   // Note: 'HH:mm' is not locale-sensitive, but we keep the locale param for future-proofing
   return format(date, 'HH:mm')
+}
+
+export function compareEntriesByStartTime(a: TimeEntry, b: TimeEntry) {
+  const aIsDuration = typeof a.durationMinutes === 'number'
+  const bIsDuration = typeof b.durationMinutes === 'number'
+  if (aIsDuration && !bIsDuration) return 1
+  if (!aIsDuration && bIsDuration) return -1
+  if (!aIsDuration && !bIsDuration && a.startTime && b.startTime) {
+    return b.startTime.getTime() - a.startTime.getTime()
+  }
+  if (!aIsDuration && !bIsDuration && a.startTime && !b.startTime) return -1
+  if (!aIsDuration && !bIsDuration && !a.startTime && b.startTime) return 1
+  // Both are duration entries, sort by startTime descending
+  if (a.startTime && b.startTime) {
+    return b.startTime.getTime() - a.startTime.getTime()
+  }
+  return 0
 }

--- a/src/services/time-entry-service.local.ts
+++ b/src/services/time-entry-service.local.ts
@@ -1,6 +1,7 @@
 import { set, subDays } from 'date-fns'
 
 import type { TimeEntry } from '@/lib/types'
+import { compareEntriesByStartTime } from '@/lib/utils'
 
 let entries: TimeEntry[] = []
 
@@ -126,6 +127,19 @@ if (process.env.NEXT_PUBLIC_ENVIRONMENT == 'development') {
       travelTime: 0,
       isDriver: false,
     },
+    {
+      id: '7',
+      userId: 'mock-user-1',
+      location: 'Duration Only Example',
+      durationMinutes: 15,
+      startTime: set(new Date(), {
+        hours: 12,
+        minutes: 0,
+        seconds: 0,
+        milliseconds: 0,
+      }),
+      // No endTime
+    },
   ]
 }
 
@@ -156,7 +170,7 @@ export const deleteTimeEntry = async (
 export const getTimeEntries = async (userId: string): Promise<TimeEntry[]> => {
   return entries
     .filter((e) => e.userId === userId)
-    .sort((a, b) => b.startTime.getTime() - a.startTime.getTime())
+    .sort(compareEntriesByStartTime)
 }
 
 export const deleteAllTimeEntries = async (userId: string): Promise<void> => {


### PR DESCRIPTION
This pull request introduces support for "duration-only" time entries, alongside existing interval-based entries. Key changes include updates to the time entry form, backend logic, and test cases to accommodate the new entry type.

### New Feature: Duration-Only Time Entries

* **Time Entry Form Enhancements**:
  - Added a mode switch (`interval` vs. `duration`) to the time entry form, allowing users to specify either a time range or a duration in minutes. Validation rules were updated to ensure proper handling of both modes. (`src/components/time-entry-form.tsx`) [[1]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR77-R99) [[2]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR109-R126) [[3]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR157-R186) [[4]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbL292-R384) [[5]](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbR522-R545)
  - Introduced logic for creating duration-only entries, which default to a start time of 12:00 PM on the selected date. (`src/components/time-entry-form.tsx`)

* **Display and Calculation Updates**:
  - Updated `TimeEntryCard` to render duration-only entries with a duration label (e.g., "90 min") instead of a time range. (`src/components/time-entry-card.tsx`) [[1]](diffhunk://#diff-4c12ebd32f44bbe19043b43e8b22d7ace1b45af7c21d6513c2a3623b63075ef9R72-R83) [[2]](diffhunk://#diff-4c12ebd32f44bbe19043b43e8b22d7ace1b45af7c21d6513c2a3623b63075ef9R186-R201)
  - Adjusted calculation methods to account for entries with a `durationMinutes` field. (`src/components/time-entry-card.tsx`)

### Backend and Utility Updates

* **Sorting and Aggregation Logic**:
  - Replaced manual sorting logic with a new utility function, `compareEntriesByStartTime`, for consistency. (`src/components/export-preview.tsx`) [[1]](diffhunk://#diff-8cb1caeb7315d788ea40c30cf4db96da27bcefa20b71c9fdb94d45546d8834c8R31) [[2]](diffhunk://#diff-8cb1caeb7315d788ea40c30cf4db96da27bcefa20b71c9fdb94d45546d8834c8L79-R80) [[3]](diffhunk://#diff-8cb1caeb7315d788ea40c30cf4db96da27bcefa20b71c9fdb94d45546d8834c8L188-R191)
  - Modified aggregation logic to include duration-only entries in total time calculations. (`src/components/export-preview.tsx`)

### Testing Enhancements

* **End-to-End Tests**:
  - Added a helper function, `addDurationEntry`, to create duration-only entries during tests. (`e2e/test-helpers.ts`)
  - Introduced a new E2E test to verify the creation, display, and deletion of duration-only entries. (`e2e/tracker.spec.ts`)

* **Unit Tests**:
  - Added unit tests for `TimeEntryCard` to ensure correct rendering of duration-only entries. (`src/components/__tests__/time-entry-card.test.tsx`) 

These changes collectively enable users to input and manage time entries based solely on duration, improving flexibility and usability.