### PR TITLE
feat: add default driver and display name to the settings

### DIFF
--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -102,4 +102,70 @@ test.describe('Settings Page', () => {
     await expect(page.getByText('0302334567')).toBeVisible()
     await expect(page.getByText('0300456789')).toBeVisible()
   })
+
+  test('should update display name and see it in the export preview', async ({
+    page,
+  }) => {
+    // Go to settings
+    await page.getByRole('link', { name: 'Einstellungen' }).click()
+    await page.waitForURL('/settings')
+    // Fill display name
+    await page.getByLabel('Anzeigename').fill('Malcolm X')
+    await page.getByRole('button', { name: 'Einstellungen speichern' }).click()
+    await expect(page.locator('[data-testid="toast-title"]')).toContainText(
+      'Einstellungen gespeichert',
+    )
+    // Go back to overview and then to export page
+    await page.getByRole('link', { name: 'Zurück zur Übersicht' }).click()
+    await page.waitForURL('/')
+    await page.getByRole('link', { name: 'Vorschau & Export' }).click()
+    await page.waitForURL('/export')
+    // Check for display name in export preview
+    await expect(page.getByText('Malcolm X')).toBeVisible()
+  })
+
+  test('should update default driver and see it marked in the time form', async ({
+    page,
+  }) => {
+    // Go to settings
+    await page.getByRole('link', { name: 'Einstellungen' }).click()
+    await page.waitForURL('/settings')
+    // Set default driver checkbox
+    await page.getByLabel('Standardmäßig als Fahrer').click()
+    await expect(page.getByLabel('Standardmäßig als Fahrer')).toBeChecked()
+    await page.getByRole('button', { name: 'Einstellungen speichern' }).click()
+    await expect(page.locator('[data-testid="toast-title"]')).toContainText(
+      'Einstellungen gespeichert',
+    )
+    // Go back to overview and then to time form
+    await page.getByRole('link', { name: 'Zurück zur Übersicht' }).click()
+    await page.waitForURL('/')
+    await page.getByRole('button', { name: /Hinzufügen|Add/i }).click()
+    const dialog = page.locator('div[role="dialog"]')
+    await expect(dialog).toBeVisible()
+    // Check for default driver marked in the time form
+    await expect(page.getByLabel('Fahrer')).toBeChecked()
+    // Cancel the dialog
+    await page.getByRole('button', { name: /Abbrechen|Cancel/i }).click()
+    await page.getByRole('button', { name: /Verwerfen|Discard/i }).click()
+    await expect(dialog).not.toBeVisible()
+
+    // Go back to settings and unset default driver
+    await page.getByRole('link', { name: 'Einstellungen' }).click()
+    await page.waitForURL('/settings')
+    // Unset default driver checkbox
+    await page.getByLabel('Standardmäßig als Fahrer').click()
+    await expect(page.getByLabel('Standardmäßig als Fahrer')).not.toBeChecked()
+    await page.getByRole('button', { name: 'Einstellungen speichern' }).click()
+    await expect(page.locator('[data-testid="toast-title"]')).toContainText(
+      'Einstellungen gespeichert',
+    )
+    // Go back to overview and then to time form
+    await page.getByRole('link', { name: 'Zurück zur Übersicht' }).click()
+    await page.waitForURL('/')
+    await page.getByRole('button', { name: /Hinzufügen|Add/i }).click()
+    await expect(dialog).toBeVisible()
+    // Check for default driver marked in the time form
+    await expect(page.getByLabel('Fahrer')).not.toBeChecked()
+  })
 })

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -58,6 +58,8 @@ const settingsFormSchema = z.object({
     .string()
     .regex(/^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/, 'Invalid time format (HH:mm)'),
   language: z.enum(['en', 'de']),
+  defaultIsDriver: z.boolean().optional(),
+  displayName: z.string().optional(), // New
   companyName: z.string().optional(),
   companyEmail: z.string().email().optional().or(z.literal('')),
   companyPhone1: z.string().optional(),
@@ -83,6 +85,8 @@ export default function SettingsPage() {
       defaultStartTime: '09:00',
       defaultEndTime: '17:00',
       language: language,
+      defaultIsDriver: false,
+      displayName: '', // New
       companyName: '',
       companyEmail: '',
       companyPhone1: '',
@@ -116,7 +120,8 @@ export default function SettingsPage() {
       }
       fetchSettings()
     }
-  }, [user, form, toast, t])
+    // Only depend on user and form.reset to avoid unnecessary resets
+  }, [user, form.reset])
 
   const onSubmit = async (data: SettingsFormValues) => {
     if (!user) return
@@ -210,6 +215,52 @@ export default function SettingsPage() {
                       </p>
                     </FormItem>
                   )}
+                />
+                <FormField
+                  control={form.control}
+                  name="defaultIsDriver"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-center gap-4 mb-2">
+                      <FormControl>
+                        <input
+                          type="checkbox"
+                          checked={field.value}
+                          onChange={(e) => field.onChange(e.target.checked)}
+                          id="defaultIsDriver"
+                        />
+                      </FormControl>
+                      <div className="space-y-1 leading-none">
+                        <FormLabel htmlFor="defaultIsDriver">
+                          {t('settings.defaultIsDriverLabel')}
+                        </FormLabel>
+                        <FormDescription>
+                          {t('settings.defaultIsDriverDescription')}
+                        </FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="displayName"
+                  render={({ field }) => {
+                    console.log('Field props:', field)
+                    return (
+                      <FormItem>
+                        <FormLabel>{t('settings.displayNameLabel')}</FormLabel>
+                        <FormControl>
+                          <Input
+                            placeholder={t('settings.displayNamePlaceholder')}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          {t('settings.displayNameDescription')}
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )
+                  }}
                 />
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <FormField

--- a/src/components/time-entry-form.tsx
+++ b/src/components/time-entry-form.tsx
@@ -178,7 +178,10 @@ export default function TimeEntryForm({
       duration: defaultDuration,
       pauseDuration: formatMinutesToTimeInput(entry?.pauseDuration ?? 0),
       travelTime: entry?.travelTime || 0,
-      isDriver: entry?.isDriver || false,
+      isDriver:
+        entry?.isDriver !== undefined
+          ? entry.isDriver
+          : (userSettings?.defaultIsDriver ?? false),
     },
   })
 

--- a/src/components/timesheet-preview.tsx
+++ b/src/components/timesheet-preview.tsx
@@ -100,7 +100,11 @@ export default function TimesheetPreview({
             })}
           </h1>
           <div className="text-right font-semibold print:text-sm">
-            {user?.displayName || user?.email}
+            {
+              (userSettings?.displayName?.trim() ||
+                user?.displayName ||
+                user?.email) as string
+            }
           </div>
         </header>
       </div>

--- a/src/lib/excel-export.ts
+++ b/src/lib/excel-export.ts
@@ -115,8 +115,10 @@ export const exportToExcel = async ({
 
   worksheet.mergeCells(titleRow.number, 1, titleRow.number, 5)
 
+  const userExportName =
+    userSettings.displayName?.trim() || user?.displayName || user?.email || ''
   const userCell = titleRow.getCell('J')
-  userCell.value = user?.displayName || user?.email
+  userCell.value = userExportName
   userCell.font = { bold: true, size: 10 }
   userCell.alignment = { horizontal: 'right' }
 
@@ -394,7 +396,7 @@ export const exportToExcel = async ({
   const url = window.URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `Stundenzettel_${user?.displayName || 'Export'}_${format(selectedMonth, 'yyyy-MM')}.xlsx`
+  a.download = `Stundenzettel_${userExportName || 'Export'}_${format(selectedMonth, 'yyyy-MM')}.xlsx`
   document.body.appendChild(a)
   a.click()
   window.URL.revokeObjectURL(url)

--- a/src/lib/i18n/dictionaries.ts
+++ b/src/lib/i18n/dictionaries.ts
@@ -177,6 +177,9 @@ export const dictionaries = {
       defaultStartTimeLabel: 'Default start time',
       defaultEndTimeLabel: 'Default end time',
       timeUsageDescription: 'Used for new time entries.',
+      defaultIsDriverLabel: 'Default to main driver',
+      defaultIsDriverDescription:
+        'If enabled, new entries will have "main driver" checked by default.',
       languageLabel: 'Language',
       languageEnglish: 'English',
       languageGerman: 'German',
@@ -196,6 +199,10 @@ export const dictionaries = {
       savedDescription: 'Your new settings have been applied.',
       errorSavingTitle: 'Error',
       errorSavingDescription: 'Could not save your settings.',
+      displayNameLabel: 'Display Name',
+      displayNameDescription:
+        'This name will appear on your export preview and Excel file. Leave blank to use your account name.',
+      displayNamePlaceholder: 'e.g. John Doe',
     },
     // Export Page
     export_page: {
@@ -429,6 +436,9 @@ export const dictionaries = {
       defaultStartTimeLabel: 'Standard-Startzeit',
       defaultEndTimeLabel: 'Standard-Endzeit',
       timeUsageDescription: 'Wird für neue Zeiteinträge verwendet.',
+      defaultIsDriverLabel: 'Standardmäßig als Fahrer',
+      defaultIsDriverDescription:
+        'Wenn aktiviert, ist "Fahrer" bei neuen Einträgen standardmäßig ausgewählt.',
       languageLabel: 'Sprache',
       languageEnglish: 'Englisch',
       languageGerman: 'Deutsch',
@@ -450,6 +460,10 @@ export const dictionaries = {
       errorSavingTitle: 'Fehler',
       errorSavingDescription:
         'Ihre Einstellungen konnten nicht gespeichert werden.',
+      displayNameLabel: 'Anzeigename',
+      displayNameDescription:
+        'Dieser Name erscheint in der Export-Vorschau und in der Excel-Datei. Leer lassen, um den Kontonamen zu verwenden.',
+      displayNamePlaceholder: 'z.B. Max Mustermann',
     },
     // Export Page
     export_page: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,8 @@ export interface UserSettings {
   defaultStartTime: string
   defaultEndTime: string
   language: 'en' | 'de'
+  defaultIsDriver?: boolean
+  displayName?: string
   companyName?: string
   companyEmail?: string
   companyPhone1?: string

--- a/src/services/__tests__/user-settings-service.test.ts
+++ b/src/services/__tests__/user-settings-service.test.ts
@@ -13,6 +13,8 @@ describe('User Settings Service (Local Implementation)', () => {
     defaultStartTime: '09:00',
     defaultEndTime: '17:00',
     language: 'en',
+    defaultIsDriver: false,
+    displayName: '',
     companyName: '',
     companyEmail: '',
     companyPhone1: '',
@@ -22,10 +24,11 @@ describe('User Settings Service (Local Implementation)', () => {
 
   it('should get custom settings for a pre-configured user', async () => {
     const settings = await getUserSettings(existingUserIdWithCustomSettings)
-
     expect(settings.language).toBe('de')
     expect(settings.companyName).toBe('Acme Inc.')
     expect(settings.defaultWorkHours).toBe(7)
+    expect(settings.displayName).toBe('')
+    expect(settings.defaultIsDriver).toBe(false)
   })
 
   it('should return default settings for a new user', async () => {
@@ -38,19 +41,24 @@ describe('User Settings Service (Local Implementation)', () => {
       language: 'en',
       defaultWorkHours: 8.5,
       companyName: 'Test Corp Inc.',
+      defaultIsDriver: true,
+      displayName: 'Export Name',
     }
-
-    // Cast to UserSettings as the service expects the full object, even though we test partial update logic
     await setUserSettings(newUserId, settingsToSet as UserSettings)
-
     const updatedSettings = await getUserSettings(newUserId)
-
-    // Check that the new settings were applied and merged with defaults
     expect(updatedSettings.language).toBe('en')
     expect(updatedSettings.defaultWorkHours).toBe(8.5)
     expect(updatedSettings.companyName).toBe('Test Corp Inc.')
     expect(updatedSettings.defaultStartTime).toBe(
       defaultSettings.defaultStartTime,
-    ) // Check a default value is still there
+    )
+    expect(updatedSettings.defaultIsDriver).toBe(true)
+    expect(updatedSettings.displayName).toBe('Export Name')
+  })
+
+  it('should allow clearing displayName (blank fallback)', async () => {
+    await setUserSettings(newUserId, { displayName: '' } as UserSettings)
+    const updatedSettings = await getUserSettings(newUserId)
+    expect(updatedSettings.displayName).toBe('')
   })
 })

--- a/src/services/user-settings-service.firestore.ts
+++ b/src/services/user-settings-service.firestore.ts
@@ -8,6 +8,8 @@ const defaultSettings: UserSettings = {
   defaultStartTime: '09:00',
   defaultEndTime: '17:00',
   language: 'en',
+  defaultIsDriver: false,
+  displayName: '', // New
   companyName: '',
   companyEmail: '',
   companyPhone1: '',

--- a/src/services/user-settings-service.local.ts
+++ b/src/services/user-settings-service.local.ts
@@ -7,12 +7,15 @@ const userSettings: { [userId: string]: Partial<UserSettings> } = {
     defaultEndTime: '17:00',
     language: 'de',
     companyName: 'Acme Inc.',
+    defaultIsDriver: false,
   },
   'mock-user-2': {
     defaultWorkHours: 7.5,
     defaultStartTime: '08:30',
     defaultEndTime: '16:30',
     language: 'en',
+    defaultIsDriver: false,
+    displayName: 'Max Mustermann',
   },
 }
 
@@ -21,6 +24,8 @@ const defaultSettings: UserSettings = {
   defaultStartTime: '09:00',
   defaultEndTime: '17:00',
   language: 'en',
+  defaultIsDriver: false,
+  displayName: '',
   companyName: '',
   companyEmail: '',
   companyPhone1: '',


### PR DESCRIPTION
This pull request introduces two new user settings, `defaultIsDriver` and `displayName`, and integrates them throughout the application. These changes include updates to the settings page, default values, form validation, and their usage in export previews and Excel exports. Additionally, tests and localization dictionaries have been updated to support the new functionality.

### New User Settings Integration:

* [`src/lib/types.ts`](diffhunk://#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R25-R26): Added `defaultIsDriver` (boolean) and `displayName` (string) as optional properties in the `UserSettings` interface.
* [`src/app/settings/page.tsx`](diffhunk://#diff-4f02d75464a64da0318349942d498911325a4e2955e5d9e9b676d4305a9b0b9dR61-R62): Updated the settings form schema and default values to include `defaultIsDriver` and `displayName`. Added corresponding form fields for user input. [[1]](diffhunk://#diff-4f02d75464a64da0318349942d498911325a4e2955e5d9e9b676d4305a9b0b9dR61-R62) [[2]](diffhunk://#diff-4f02d75464a64da0318349942d498911325a4e2955e5d9e9b676d4305a9b0b9dR88-R89) [[3]](diffhunk://#diff-4f02d75464a64da0318349942d498911325a4e2955e5d9e9b676d4305a9b0b9dR219-R264)

### Application Behavior Updates:

* [`src/components/time-entry-form.tsx`](diffhunk://#diff-015a77125f7eecb4e3f9557d75e9321a9e380b308218de95220ba6da8b3e00cbL181-R184): Modified to use `defaultIsDriver` for pre-selecting the "main driver" checkbox in new time entries.
* `src/components/timesheet-preview.tsx` and `src/lib/excel-export.ts`: Adjusted to display `displayName` in export previews and Excel file names, falling back to the user's account name or email if `displayName` is not set. [[1]](diffhunk://#diff-5cc44cd000e2d7bd9209e8189171aac942bff3c2530293409d8b4ae755e08db6L103-R107) [[2]](diffhunk://#diff-affa3e34b68aa50361ce52996737a8da3810b7fad373870567661ef868a5b8eeR118-R121) [[3]](diffhunk://#diff-affa3e34b68aa50361ce52996737a8da3810b7fad373870567661ef868a5b8eeL397-R399)

### Testing Enhancements:

* [`src/app/settings/__tests__/page.test.tsx`](diffhunk://#diff-acffe28ef117c496cf1f2350d317695815f9d37cc25f5184542203d906414fdeR66-R81): Added tests for setting and clearing `displayName` and toggling `defaultIsDriver`. Updated mock settings to include the new properties. [[1]](diffhunk://#diff-acffe28ef117c496cf1f2350d317695815f9d37cc25f5184542203d906414fdeR66-R81) [[2]](diffhunk://#diff-acffe28ef117c496cf1f2350d317695815f9d37cc25f5184542203d906414fdeR90) [[3]](diffhunk://#diff-acffe28ef117c496cf1f2350d317695815f9d37cc25f5184542203d906414fdeR99-R149) [[4]](diffhunk://#diff-acffe28ef117c496cf1f2350d317695815f9d37cc25f5184542203d906414fdeR176-R182)
* [`src/services/__tests__/user-settings-service.test.ts`](diffhunk://#diff-de6ae8593886fc1b5b651ad09320d150f140e0913d28975ca97fb1b27654a1b1R16-R17): Extended tests for the user settings service to validate the handling of `defaultIsDriver` and `displayName`. [[1]](diffhunk://#diff-de6ae8593886fc1b5b651ad09320d150f140e0913d28975ca97fb1b27654a1b1R16-R17) [[2]](diffhunk://#diff-de6ae8593886fc1b5b651ad09320d150f140e0913d28975ca97fb1b27654a1b1L25-R31) [[3]](diffhunk://#diff-de6ae8593886fc1b5b651ad09320d150f140e0913d28975ca97fb1b27654a1b1R44-R62)

### Localization Updates:

* [`src/lib/i18n/dictionaries.ts`](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R180-R182): Added translations for `defaultIsDriver` and `displayName` labels, descriptions, and placeholders in both English and German. [[1]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R180-R182) [[2]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R202-R205) [[3]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R439-R441) [[4]](diffhunk://#diff-544ca90236ac28c7e01c1b9d5ff07903eaa4519730a5a885b84db7d90fc8be34R463-R466)

### Default Settings Adjustments:

* `src/services/user-settings-service.local.ts` and `src/services/user-settings-service.firestore.ts`: Updated default settings to include `defaultIsDriver` (false) and `displayName` (empty string). [[1]](diffhunk://#diff-96ef007cc87970ab4b1548fc453e2867c977d44c4fa0b50fbae0063a5e931b4fR10-R18) [[2]](diffhunk://#diff-96ef007cc87970ab4b1548fc453e2867c977d44c4fa0b50fbae0063a5e931b4fR27-R28) [[3]](diffhunk://#diff-0ab3f284a2f7e9bf640d17092c49b9199aca64906d89d414c63af3ffa98c4d0bR11-R12)