### PR TITLE
chore(deps): downgrade zod, as it's causing issues we don't know how to solve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "react-hook-form": "^7.54.2",
         "tailwind-merge": "3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^4.0.0"
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@playwright/test": "^1.45.3",
@@ -3801,16 +3801,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -13527,16 +13517,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/firebase-tools/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/firebase/node_modules/@firebase/auth": {
@@ -28730,9 +28710,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-hook-form": "^7.54.2",
     "tailwind-merge": "3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.0.0"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@playwright/test": "^1.45.3",


### PR DESCRIPTION
This pull request includes a version downgrade for the `zod` library in the `package.json` file.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L66-R66): Downgraded `zod` from version `^4.0.0` to `^3.25.76`.