### PR TITLE
hotfix: hardcode defaultTimezone

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,7 +56,7 @@ export default async function RootLayout({
         className={`font-body antialiased ${lora.variable} ${ptSans.variable}`}
       >
         <AuthProvider>
-          <NextIntlClientProvider>
+          <NextIntlClientProvider timeZone={'Europe/Berlin'}>
             {children}
             <Toaster />
           </NextIntlClientProvider>

--- a/src/lib/i18n/formats.ts
+++ b/src/lib/i18n/formats.ts
@@ -1,6 +1,5 @@
 import { Formats } from 'use-intl'
 
-const defaultTimezone = 'Europe/Berlin'
 export const formattingProps: Formats = {
   dateTime: {
     long: {
@@ -8,38 +7,30 @@ export const formattingProps: Formats = {
       day: 'numeric',
       year: 'numeric',
       weekday: 'long',
-      timeZone: defaultTimezone,
     },
     short: {
       month: 'numeric',
       day: 'numeric',
       year: 'numeric',
-      timeZone: defaultTimezone,
     },
     shortTime: {
       hour: '2-digit',
       minute: '2-digit',
       hour12: false,
-      timeZone: defaultTimezone,
     },
     month: {
       month: 'long',
-      timeZone: defaultTimezone,
     },
     monthYear: {
       month: 'long',
       year: 'numeric',
-      timeZone: defaultTimezone,
     },
     yearMonth: {
       year: 'numeric',
       month: 'numeric',
-      timeZone: defaultTimezone,
-
     },
     weekday: {
       weekday: 'short',
-      timeZone: defaultTimezone,
     },
   },
   number: {

--- a/src/lib/i18n/formats.ts
+++ b/src/lib/i18n/formats.ts
@@ -1,5 +1,6 @@
 import { Formats } from 'use-intl'
 
+const defaultTimezone = 'Europe/Berlin'
 export const formattingProps: Formats = {
   dateTime: {
     long: {
@@ -7,30 +8,38 @@ export const formattingProps: Formats = {
       day: 'numeric',
       year: 'numeric',
       weekday: 'long',
+      timeZone: defaultTimezone,
     },
     short: {
       month: 'numeric',
       day: 'numeric',
       year: 'numeric',
+      timeZone: defaultTimezone,
     },
     shortTime: {
       hour: '2-digit',
       minute: '2-digit',
       hour12: false,
+      timeZone: defaultTimezone,
     },
     month: {
       month: 'long',
+      timeZone: defaultTimezone,
     },
     monthYear: {
       month: 'long',
       year: 'numeric',
+      timeZone: defaultTimezone,
     },
     yearMonth: {
       year: 'numeric',
       month: 'numeric',
+      timeZone: defaultTimezone,
+
     },
     weekday: {
       weekday: 'short',
+      timeZone: defaultTimezone,
     },
   },
   number: {


### PR DESCRIPTION
This pull request updates the default timezone used in date and time formatting across the application. All relevant date and time format configurations in `src/lib/i18n/formats.ts` now explicitly set the timezone to 'Europe/Berlin' to ensure consistency in how dates and times are displayed.

**Internationalization improvements:**

* Set the default timezone to 'Europe/Berlin' for all date and time formats in the `formattingProps` object to ensure consistent date/time rendering throughout the application. (`src/lib/i18n/formats.ts`)