### PR TITLE
feat: export activities in timesheet when enabled in settings

### DIFF
--- a/src/components/__tests__/timesheet-preview.test.tsx
+++ b/src/components/__tests__/timesheet-preview.test.tsx
@@ -121,6 +121,61 @@ describe('TimesheetPreview', () => {
     expect(screen.getAllByText('0.50')).toHaveLength(1)
   })
 
+  it('shows activities column and values when showActivities is true', () => {
+    const entryWithActivities: TimeEntry = {
+      ...mockEntries[0],
+      activities: 'Client meeting and documentation',
+    }
+    const getEntriesForDay = (day: Date) =>
+      isSameDay(entryWithActivities.startTime, day)
+        ? [entryWithActivities]
+        : mockGetEntriesForDay(day)
+
+    render(
+      <TimesheetPreview
+        {...defaultProps}
+        entries={[entryWithActivities, mockEntries[1]]}
+        getEntriesForDay={getEntriesForDay}
+        userSettings={{
+          ...mockUserSettings,
+          showActivities: true,
+        }}
+      />,
+    )
+
+    expect(
+      screen.getAllByText('export.headerActivities').length,
+    ).toBeGreaterThan(0)
+    expect(
+      screen.getByText('Client meeting and documentation'),
+    ).toBeInTheDocument()
+  })
+
+  it('hides activities column when showActivities is false', () => {
+    render(
+      <TimesheetPreview
+        {...defaultProps}
+        entries={[
+          {
+            ...mockEntries[0],
+            activities: 'Client meeting and documentation',
+          },
+        ]}
+        userSettings={{
+          ...mockUserSettings,
+          showActivities: false,
+        }}
+      />,
+    )
+
+    expect(
+      screen.queryByText('export.headerActivities'),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Client meeting and documentation'),
+    ).not.toBeInTheDocument()
+  })
+
   it('hides edit and add buttons when readOnly is true', () => {
     render(<TimesheetPreview {...defaultProps} readOnly={true} />)
 

--- a/src/components/timesheet-preview.tsx
+++ b/src/components/timesheet-preview.tsx
@@ -61,6 +61,7 @@ export default function TimesheetPreview({
   const showDriverTimeCol = userSettings?.exportIncludeDriverTime !== false
   const showPassengerTimeCol =
     userSettings?.exportIncludePassengerTime !== false
+  const showActivitiesCol = userSettings?.showActivities === true
 
   const weeksInMonth = useMemo(
     () => getWeeksForMonth(selectedMonth),
@@ -173,28 +174,36 @@ export default function TimesheetPreview({
                     >
                       {t('export.headerPauseDuration')}
                     </TableHead>
-                    {showDriverTimeCol ? (
+                    {showDriverTimeCol && (
                       <TableHead
                         rowSpan={2}
                         className="w-[8%] border-r border-black align-middle print:h-auto print:p-1"
                       >
                         {t('export.headerDriverTime')}
                       </TableHead>
-                    ) : null}
+                    )}
                     <TableHead
                       rowSpan={2}
                       className="w-[8%] border-r border-black align-middle print:h-auto print:p-1"
                     >
                       {t('export.headerCompensatedTime')}
                     </TableHead>
-                    {showPassengerTimeCol ? (
+                    {showPassengerTimeCol && (
                       <TableHead
                         rowSpan={2}
                         className="w-[8%] border-r border-black align-middle print:h-auto print:p-1"
                       >
                         {t('export.headerPassengerTime')}
                       </TableHead>
-                    ) : null}
+                    )}
+                    {showActivitiesCol && (
+                      <TableHead
+                        rowSpan={2}
+                        className="w-auto border-r border-black text-left print:h-auto print:p-1"
+                      >
+                        {t('export.headerActivities')}
+                      </TableHead>
+                    )}
                     <TableHead
                       rowSpan={2}
                       className="w-[8%] align-middle print:h-auto print:p-1"
@@ -250,13 +259,16 @@ export default function TimesheetPreview({
                           <TableCell className="text-right print:p-1"></TableCell>
                           <TableCell className="text-right print:p-1"></TableCell>
                           <TableCell className="border-l border-r border-black text-right print:p-1"></TableCell>
-                          {showDriverTimeCol ? (
+                          {showDriverTimeCol && (
                             <TableCell className="border-r border-black text-right print:p-1"></TableCell>
-                          ) : null}
+                          )}
                           <TableCell className="border-r border-black text-right print:p-1"></TableCell>
-                          {showPassengerTimeCol ? (
+                          {showPassengerTimeCol && (
                             <TableCell className="border-r border-black text-right print:p-1"></TableCell>
-                          ) : null}
+                          )}
+                          {showActivitiesCol && (
+                            <TableCell className="border-r border-black text-left print:p-1"></TableCell>
+                          )}
                           <TableCell className="text-right print:p-1"></TableCell>
                         </TableRow>
                       )
@@ -369,21 +381,21 @@ export default function TimesheetPreview({
                               ? formatDecimalHours(entry.pauseDuration)
                               : ''}
                           </TableCell>
-                          {showDriverTimeCol ? (
+                          {showDriverTimeCol && (
                             <TableCell className="border-r border-black text-right print:p-1">
                               {entry.driverTimeHours &&
                               entry.driverTimeHours !== 0
                                 ? formatDecimalHours(entry.driverTimeHours * 60)
                                 : ''}
                             </TableCell>
-                          ) : null}
+                          )}
                           <TableCell className="border-r border-black text-right print:p-1">
                             {/* Show blank if compensated is 0 or 0.00 */}
                             {compensatedHours && compensatedHours !== 0
                               ? compensatedHours.toFixed(2)
                               : ''}
                           </TableCell>
-                          {showPassengerTimeCol ? (
+                          {showPassengerTimeCol && (
                             <TableCell className="border-r border-black text-right print:p-1">
                               {entry.passengerTimeHours &&
                               entry.passengerTimeHours !== 0
@@ -392,7 +404,12 @@ export default function TimesheetPreview({
                                   )
                                 : ''}
                             </TableCell>
-                          ) : null}
+                          )}
+                          {showActivitiesCol && (
+                            <TableCell className="border-r border-black text-left print:p-1">
+                              {entry.activities?.trim() ?? ''}
+                            </TableCell>
+                          )}
                           <TableCell className="text-right print:p-1">
                             {entry.privateCarKilometers != null &&
                             Number.isFinite(entry.privateCarKilometers) &&
@@ -422,14 +439,14 @@ export default function TimesheetPreview({
                       >
                         {weekCompTotal.toFixed(2)}
                       </div>
-                      {showPassengerTimeCol ? (
+                      {showPassengerTimeCol && (
                         <div
                           className="flex-1 text-right print:pb-0.5"
                           data-testid={`timesheet-week-${weekNumber}-passenger`}
                         >
                           {weekPassengerTotal.toFixed(2)}
                         </div>
-                      ) : null}
+                      )}
                       <div
                         className="flex-1 text-right print:pb-0.5"
                         data-testid={`timesheet-week-${weekNumber}-private-car-km`}

--- a/src/lib/__tests__/excel-export.test.ts
+++ b/src/lib/__tests__/excel-export.test.ts
@@ -205,6 +205,26 @@ describe('excel-export', () => {
       const layout = buildExcelExportColumnLayout(baseSettings)
       expect(layout.columnCount).toBe(10)
     })
+
+    it('adds activities column when showActivities is true', () => {
+      const layout = buildExcelExportColumnLayout({
+        ...baseSettings,
+        showActivities: true,
+      })
+      expect(layout.columnCount).toBe(11)
+      expect(layout.activities).toBe(10)
+      expect(layout.mileage).toBe(11)
+      expect(layout.showActivities).toBe(true)
+    })
+
+    it('omits activities column when showActivities is false or undefined', () => {
+      const layout = buildExcelExportColumnLayout({
+        ...baseSettings,
+        showActivities: false,
+      })
+      expect(layout.columnCount).toBe(10)
+      expect(layout.activities).toBeNull()
+    })
   })
 
   const mockUser: AuthenticatedUser = {
@@ -602,6 +622,37 @@ describe('excel-export', () => {
         .find((row) => row[2] === 'Office')
       expect(dataRow).toBeDefined()
       expect(dataRow![9]).toBe('42 km')
+    })
+
+    it('puts activities in the activities column when showActivities is enabled', async () => {
+      const entry: TimeEntry = {
+        id: 'entry-1',
+        userId: 'user-123',
+        location: 'Office',
+        startTime: new Date('2024-01-01T09:00:00'),
+        endTime: new Date('2024-01-01T17:00:00'),
+        activities: 'Site inspection and reporting',
+      }
+
+      const { getEntriesForDay, getLocationDisplayName } =
+        createEntryMocks(entry)
+
+      await callExportToExcel({
+        entries: [entry],
+        getEntriesForDay,
+        getLocationDisplayName,
+        userSettings: {
+          ...defaultUserSettings,
+          showActivities: true,
+        },
+      })
+
+      const dataRow = mockWorksheet.addRow.mock.calls
+        .map((c) => c[0] as unknown[])
+        .find((row) => row[2] === 'Office')
+      expect(dataRow).toBeDefined()
+      expect(dataRow![9]).toBe('Site inspection and reporting')
+      expect(dataRow![10]).toBe('')
     })
 
     it('should render entries with durationMinutes', async () => {

--- a/src/lib/excel-export.ts
+++ b/src/lib/excel-export.ts
@@ -49,10 +49,12 @@ export type ExcelExportColumnLayout = {
   driver: number | null
   compensated: number
   passenger: number | null
+  activities: number | null
   mileage: number
   columnCount: number
   showDriver: boolean
   showPassenger: boolean
+  showActivities: boolean
 }
 
 export function buildExcelExportColumnLayout(
@@ -60,6 +62,7 @@ export function buildExcelExportColumnLayout(
 ): ExcelExportColumnLayout {
   const showDriver = userSettings.exportIncludeDriverTime !== false
   const showPassenger = userSettings.exportIncludePassengerTime !== false
+  const showActivities = userSettings.showActivities === true
   let c = 1
   const week = c++
   const date = c++
@@ -70,6 +73,7 @@ export function buildExcelExportColumnLayout(
   const driver = showDriver ? c++ : null
   const compensated = c++
   const passenger = showPassenger ? c++ : null
+  const activities = showActivities ? c++ : null
   const mileage = c++
   return {
     week,
@@ -81,10 +85,12 @@ export function buildExcelExportColumnLayout(
     driver,
     compensated,
     passenger,
+    activities,
     mileage,
     columnCount: c - 1,
     showDriver,
     showPassenger,
+    showActivities,
   }
 }
 
@@ -105,6 +111,9 @@ function buildExcelHeaderRow1(
   row[layout.compensated - 1] = t('export.headerCompensatedTime')
   if (layout.passenger != null) {
     row[layout.passenger - 1] = t('export.headerPassengerTime')
+  }
+  if (layout.activities != null) {
+    row[layout.activities - 1] = t('export.headerActivities')
   }
   row[layout.mileage - 1] = t('export.headerMileage')
   return row
@@ -144,6 +153,12 @@ function styleTimesheetDataRow(
   if (layout.passenger != null) {
     dataRow.getCell(layout.passenger).alignment = { horizontal: 'right' }
     dataRow.getCell(layout.passenger).numFmt = '0.00'
+  }
+  if (layout.activities != null) {
+    dataRow.getCell(layout.activities).alignment = {
+      horizontal: 'left',
+      wrapText: true,
+    }
   }
   dataRow.getCell(layout.mileage).alignment = { horizontal: 'right' }
 }
@@ -207,6 +222,7 @@ function getExcelRowValues(
   pauseCellValue: number | ''
   driverTimeCellValue: number | ''
   passengerTimeCellValue: number | ''
+  activitiesCellValue: string
   mileageCellValue: number
 } {
   let compensatedHours = 0
@@ -242,6 +258,7 @@ function getExcelRowValues(
   const rawKm = entry.privateCarKilometers
   const mileageCellValue =
     rawKm != null && Number.isFinite(rawKm) && rawKm >= 0 ? rawKm : 0
+  const activitiesCellValue = entry.activities?.trim() ?? ''
 
   return {
     compensatedHours,
@@ -250,6 +267,7 @@ function getExcelRowValues(
     pauseCellValue,
     driverTimeCellValue,
     passengerTimeCellValue,
+    activitiesCellValue,
     mileageCellValue,
   }
 }
@@ -324,6 +342,7 @@ export const exportToExcel = async ({
     driverTime: 8,
     compensated: 8,
     passengerTime: 8,
+    activities: 24,
     mileage: 12,
   }
   worksheet.columns = Array.from({ length: layout.columnCount }, (_, i) => {
@@ -337,6 +356,7 @@ export const exportToExcel = async ({
       ...(layout.showDriver ? (['driverTime'] as const) : []),
       'compensated',
       ...(layout.showPassenger ? (['passengerTime'] as const) : []),
+      ...(layout.showActivities ? (['activities'] as const) : []),
       'mileage',
     ] as const
     const key = keys[i] ?? 'mileage'
@@ -397,6 +417,7 @@ export const exportToExcel = async ({
     if (layout.driver != null) mergeHeaderVertical(layout.driver)
     mergeHeaderVertical(layout.compensated)
     if (layout.passenger != null) mergeHeaderVertical(layout.passenger)
+    if (layout.activities != null) mergeHeaderVertical(layout.activities)
     mergeHeaderVertical(layout.mileage)
 
     // Apply styles to header rows
@@ -448,6 +469,7 @@ export const exportToExcel = async ({
             pauseCellValue,
             driverTimeCellValue,
             passengerTimeCellValue,
+            activitiesCellValue,
             mileageCellValue,
           } = getExcelRowValues(entry, userSettings, format)
 
@@ -464,6 +486,9 @@ export const exportToExcel = async ({
           rowData[layout.compensated - 1] = compensatedHours
           if (layout.passenger != null) {
             rowData[layout.passenger - 1] = passengerTimeCellValue
+          }
+          if (layout.activities != null) {
+            rowData[layout.activities - 1] = activitiesCellValue
           }
           rowData[layout.mileage - 1] = formatKilometersForExcelDisplay(
             mileageCellValue,

--- a/src/messages/de/export.json
+++ b/src/messages/de/export.json
@@ -10,6 +10,7 @@
   "headerPauseDuration": "abzgl. Pause",
   "headerDriverTime": "zzgl. FZ Fahrer",
   "headerPassengerTime": "FZ als Beifahrer",
+  "headerActivities": "Tätigkeiten",
   "headerCompensatedTime": "qualifiz. AZ",
   "headerFrom": "von",
   "headerTo": "bis",

--- a/src/messages/en/export.json
+++ b/src/messages/en/export.json
@@ -10,6 +10,7 @@
   "headerPauseDuration": "Pause (hrs)",
   "headerDriverTime": "Driver Time (hrs)",
   "headerPassengerTime": "Passenger Time (hrs)",
+  "headerActivities": "Activities",
   "headerCompensatedTime": "Compensated Hours",
   "headerFrom": "From",
   "headerTo": "To",

--- a/src/messages/es/export.json
+++ b/src/messages/es/export.json
@@ -10,6 +10,7 @@
   "headerPauseDuration": "Pausa (hrs)",
   "headerDriverTime": "Tiempo como conductor (hrs)",
   "headerPassengerTime": "Tiempo como pasajero (hrs)",
+  "headerActivities": "Actividades",
   "headerCompensatedTime": "Horas compensadas",
   "headerFrom": "Desde",
   "headerTo": "Hasta",


### PR DESCRIPTION
## Description

Time entries can include a free-text **Activities** field when **Show Activities Field** is enabled in preferences (`showActivities`). That data was saved but not shown in exported timesheets.

This PR adds an optional **Activities** column to Excel export and to the printable timesheet preview (PDF and team published reports). The column appears only when `showActivities` is true, matching the same preference that controls the field in the time entry form. Each row shows the entry’s activities text; weekly and monthly total rows leave that column empty.

## Breaking Changes

None.

## Related Issues

Fixes #
Closes #

## Testing

- [x] Unit tests added/updated and passing
- [x] E2E tests added/updated and passing (if applicable)
- [x] Manual testing completed

Manual checks:
- Enable **Show Activities Field** in Preferences, add activities to entries, export to Excel and PDF — column and values appear.
- Disable the setting — exports unchanged (no activities column).

## Checklist

- [x] Code properly formatted (`npm run format`)
- [x] Linting passes (`npm run lint`)
- [x] Documentation updated (if applicable)
- [x] New text strings internationalized (if applicable)
- [x] Firestore security rules reviewed (if applicable)
- [x] All CI checks passing

Made with [Cursor](https://cursor.com)