### PR TITLE
feat(stats): add custom date range selector with 365-day limit

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -81,7 +81,7 @@ export default defineConfig([
       'react/prop-types': 'off',
       'tailwindcss/no-custom-classname': [
         'warn',
-        { whitelist: ['printable-area'] },
+        { whitelist: ['printable-area', 'badge'] },
       ],
     },
     extends: [eslintPluginTailwindcss.configs.recommended],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import tsParser from '@typescript-eslint/parser'
 import nextVitals from 'eslint-config-next/core-web-vitals'
 import nextTs from 'eslint-config-next/typescript'
 import sonarjs from 'eslint-plugin-sonarjs'
+import eslintPluginTailwindcss from 'eslint-plugin-tailwindcss'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
@@ -76,9 +77,18 @@ export default defineConfig([
   },
   {
     files: ['**/*.tsx'],
-
     rules: {
       'react/prop-types': 'off',
+      'tailwindcss/no-custom-classname': [
+        'warn',
+        { whitelist: ['printable-area'] },
+      ],
+    },
+    extends: [eslintPluginTailwindcss.configs.recommended],
+    settings: {
+      tailwindcss: {
+        cssConfigPath: './src/app/globals.css',
+      },
     },
   },
   {

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,11 @@ const nextConfig: NextConfig = {
     ignoreBuildErrors: true,
   },
   cacheComponents: true,
+  experimental: {
+    instantInsights: {
+      validationLevel: 'manual-warning',
+    },
+  },
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "eslint-config-next": "16.2.2",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-sonarjs": "^4.0.2",
+        "eslint-plugin-tailwindcss": "^4.2.0",
         "firebase-admin": "^13.10.0",
         "firebase-functions-test": "^3.5.0",
         "firebase-tools": "^15.26.0",
@@ -5662,6 +5663,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -9885,9 +9899,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -12249,6 +12263,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -14557,6 +14578,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/eslint-plugin-tailwindcss": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-4.2.0.tgz",
+      "integrity": "sha512-TSygSjEL54Iks7K29FjvM9Lp03cpsYtbh3LJHnj/84FxCOYfLFuvQ+GioHOxgq19WGN5NbHPuvFDz/igIOEtbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.37.0",
+        "postcss": "^8.4.4",
+        "postcss-nested": "^7.0.2",
+        "synckit": "^0.11.11",
+        "tailwind-api-utils": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0",
+        "tailwindcss": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -15197,6 +15244,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
       "license": "MIT"
     },
@@ -20937,6 +20991,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/local-pkg": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.4",
+        "pkg-types": "^2.3.0",
+        "quansync": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -22528,6 +22600,38 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/moo": {
@@ -25849,6 +25953,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/peberminta": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
@@ -26129,6 +26240,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -26238,6 +26361,46 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-7.0.2.tgz",
+      "integrity": "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postgres-array": {
@@ -26736,6 +26899,23 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quansync": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+      "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/antfu"
+        },
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/sxzz"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -29570,6 +29750,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/synckit": {
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.3.6"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -29581,6 +29777,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tailwind-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tailwind-api-utils/-/tailwind-api-utils-1.0.3.tgz",
+      "integrity": "sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "local-pkg": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hyoban"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.3.0 || ^4.0.0 || ^4.0.0-beta"
       }
     },
     "node_modules/tailwind-merge": {
@@ -30432,6 +30646,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "eslint-config-next": "16.2.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-sonarjs": "^4.0.2",
+    "eslint-plugin-tailwindcss": "^4.2.0",
     "firebase-admin": "^13.10.0",
     "firebase-functions-test": "^3.5.0",
     "firebase-tools": "^15.26.0",

--- a/src/app/(app)/company/page.tsx
+++ b/src/app/(app)/company/page.tsx
@@ -193,14 +193,14 @@ export default function CompanyPage() {
 
   return (
     <SubscriptionGuard>
-      <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+      <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
         <div className="mx-auto max-w-2xl">
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
-                    <Building className="h-5 w-5" />
+                    <Building className="size-5" />
                     {t('settings.company')}
                   </CardTitle>
                   <CardDescription>
@@ -311,7 +311,7 @@ export default function CompanyPage() {
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
-                    <Percent className="h-5 w-5" />
+                    <Percent className="size-5" />
                     {t('settings.compensationSettings')}
                   </CardTitle>
                 </CardHeader>
@@ -397,7 +397,7 @@ export default function CompanyPage() {
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
-                    <FileSpreadsheet className="h-5 w-5" />
+                    <FileSpreadsheet className="size-5" />
                     {t('settings.exportSettings')}
                   </CardTitle>
                 </CardHeader>
@@ -470,11 +470,11 @@ export default function CompanyPage() {
               >
                 {isSaving ? (
                   <Loader2
-                    className="mr-2 h-4 w-4 animate-spin"
+                    className="mr-2 size-4 animate-spin"
                     data-testid="loader-icon"
                   />
                 ) : (
-                  <Save className="mr-2 h-4 w-4" />
+                  <Save className="mr-2 size-4" />
                 )}
                 {isSaving ? t('common.saving') : t('common.save')}
               </Button>

--- a/src/app/(app)/export/page.tsx
+++ b/src/app/(app)/export/page.tsx
@@ -28,7 +28,7 @@ export default function ExportPage() {
     <SubscriptionGuard>
       <TooltipProvider>
         <TimeTrackerProvider user={user}>
-          <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8 print:bg-white print:p-0">
+          <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8 print:bg-white print:p-0">
             <div className="mx-auto max-w-7xl print:mx-0 print:max-w-none">
               <ExportPreview />
             </div>

--- a/src/app/(app)/preferences/page.tsx
+++ b/src/app/(app)/preferences/page.tsx
@@ -212,14 +212,14 @@ export default function PreferencesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+    <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
       <div className="mx-auto max-w-2xl">
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                  <Settings className="h-5 w-5" />
+                  <Settings className="size-5" />
                   {t('settings.preferences')}
                 </CardTitle>
                 <CardDescription>
@@ -302,7 +302,7 @@ export default function PreferencesPage() {
                           <TooltipProvider>
                             <Tooltip>
                               <TooltipTrigger asChild>
-                                <InfoIcon className="h-4 w-4 text-muted-foreground" />
+                                <InfoIcon className="size-4 text-muted-foreground" />
                               </TooltipTrigger>
                               <TooltipContent>
                                 <p className="max-w-xs">
@@ -342,7 +342,7 @@ export default function PreferencesPage() {
                               form.setValue('expectedMonthlyHours', calculated)
                               setIsExpectedHoursManuallySet(false)
                             }}
-                            className="ml-2 text-sm text-primary hover:text-primary/80 underline"
+                            className="ml-2 text-sm text-primary underline hover:text-primary/80"
                           >
                             {t('settings.resetToAutoCalculation')}
                           </button>
@@ -353,7 +353,7 @@ export default function PreferencesPage() {
                   )}
                 />
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <FormField
                     control={form.control}
                     name="defaultStartTime"
@@ -440,11 +440,11 @@ export default function PreferencesPage() {
                 >
                   {isSaving ? (
                     <Loader2
-                      className="mr-2 h-4 w-4 animate-spin"
+                      className="mr-2 size-4 animate-spin"
                       data-testid="loader-icon"
                     />
                   ) : (
-                    <Save className="mr-2 h-4 w-4" />
+                    <Save className="mr-2 size-4" />
                   )}
                   {isSaving ? t('common.saving') : t('common.save')}
                 </Button>

--- a/src/app/(app)/security/page.tsx
+++ b/src/app/(app)/security/page.tsx
@@ -80,13 +80,13 @@ export default function SecurityPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+    <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
       <div className="mx-auto max-w-2xl">
         <div className="space-y-6">
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <Shield className="h-5 w-5" />
+                <Shield className="size-5" />
                 {t('settings.security')}
               </CardTitle>
               <CardDescription>
@@ -94,7 +94,7 @@ export default function SecurityPage() {
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="flex items-center justify-between p-4 border rounded-lg">
+              <div className="flex items-center justify-between rounded-lg border p-4">
                 <div>
                   <h3 className="font-medium">{t('settings.accountEmail')}</h3>
                   <p className="text-sm text-muted-foreground">{user.email}</p>
@@ -132,7 +132,7 @@ export default function SecurityPage() {
 
               {/* Password change section - only show for email users */}
               {!checkingPasswordAuth && hasPasswordAuth && (
-                <div className="flex items-center justify-between p-4 border rounded-lg">
+                <div className="flex items-center justify-between rounded-lg border p-4">
                   <div>
                     <h3 className="font-medium">{t('settings.password')}</h3>
                     <p className="text-sm text-muted-foreground">

--- a/src/app/(app)/stats/page.tsx
+++ b/src/app/(app)/stats/page.tsx
@@ -24,7 +24,7 @@ export default function StatsPage() {
 
   return (
     <TimeTrackerProvider user={user}>
-      <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+      <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
         <div className="mx-auto max-w-7xl">
           <StatsView />
         </div>

--- a/src/app/(app)/subscription/page.tsx
+++ b/src/app/(app)/subscription/page.tsx
@@ -112,12 +112,12 @@ export default function SubscriptionPage() {
     subscription?.status === 'active' || subscription?.status === 'trialing'
 
   return (
-    <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+    <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
       <div className="mx-auto max-w-2xl">
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <CreditCard className="h-5 w-5" />
+              <CreditCard className="size-5" />
               {t('settings.manageSubscription')}
             </CardTitle>
             <CardDescription>
@@ -126,27 +126,27 @@ export default function SubscriptionPage() {
           </CardHeader>
           <CardContent className="space-y-6">
             {!isSubscribed ? (
-              <div className="text-center py-8">
-                <Crown className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                <h3 className="text-lg font-medium mb-2">
+              <div className="py-8 text-center">
+                <Crown className="mx-auto mb-4 size-12 text-muted-foreground" />
+                <h3 className="mb-2 text-lg font-medium">
                   {t('subscription.noSubscription')}
                 </h3>
-                <p className="text-muted-foreground mb-4">
+                <p className="mb-4 text-muted-foreground">
                   {t('subscription.noSubscriptionDescription')}
                 </p>
                 <Button onClick={handleUpgrade}>
-                  <ExternalLink className="h-4 w-4 mr-2" />
+                  <ExternalLink className="mr-2 size-4" />
                   {t('subscription.upgrade')}
                 </Button>
               </div>
             ) : (
               <div className="space-y-4">
-                <div className="flex items-center justify-between p-4 border rounded-lg">
+                <div className="flex items-center justify-between rounded-lg border p-4">
                   <div>
-                    <h4 className="text-xs font-medium mb-2">
+                    <h4 className="mb-2 text-xs font-medium">
                       {t('subscription.currentPlan')}
                     </h4>
-                    <h3 className="font-headline text-xl font-semibold leading-none tracking-tight">
+                    <h3 className="font-headline text-xl leading-none font-semibold tracking-tight">
                       {subscription?.planName ?? t('subscription.unknownPlan')}
                     </h3>
                     <p className="text-xs text-muted-foreground">
@@ -166,14 +166,14 @@ export default function SubscriptionPage() {
 
                 {/* Trial Information */}
                 {isInTrial && trialEndDate && (
-                  <div className="p-4 border rounded-lg bg-blue-50 dark:bg-blue-950/20">
+                  <div className="rounded-lg border bg-blue-50 p-4 dark:bg-blue-950/20">
                     <div className="flex items-start gap-3">
-                      <Clock className="h-5 w-5 text-blue-600 mt-0.5" />
+                      <Clock className="mt-0.5 size-5 text-blue-600" />
                       <div className="flex-1">
                         <h3 className="font-medium text-blue-900 dark:text-blue-100">
                           {t('subscription.trialStatus')}
                         </h3>
-                        <p className="text-sm text-blue-700 dark:text-blue-300 mb-2">
+                        <p className="mb-2 text-sm text-blue-700 dark:text-blue-300">
                           {daysRemaining !== null && daysRemaining > 0
                             ? t('subscription.trialDaysRemaining', {
                                 days: daysRemaining,
@@ -191,14 +191,14 @@ export default function SubscriptionPage() {
 
                 {/* Trial Expiration Warning */}
                 {isInTrial && isTrialExpiringSoon && (
-                  <div className="p-4 border border-orange-200 rounded-lg bg-orange-50 dark:bg-orange-950/20">
+                  <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:bg-orange-950/20">
                     <div className="flex items-start gap-3">
-                      <AlertTriangle className="h-5 w-5 text-orange-600 mt-0.5" />
+                      <AlertTriangle className="mt-0.5 size-5 text-orange-600" />
                       <div className="flex-1">
                         <h3 className="font-medium text-orange-900 dark:text-orange-100">
                           {t('subscription.trialExpiringSoon')}
                         </h3>
-                        <p className="text-sm text-orange-700 dark:text-orange-300 mb-3">
+                        <p className="mb-3 text-sm text-orange-700 dark:text-orange-300">
                           {t('subscription.trialExpiringDescription')}
                         </p>
                       </div>
@@ -208,7 +208,7 @@ export default function SubscriptionPage() {
 
                 {/* Cancellation Information */}
                 {subscription?.cancelAt && (
-                  <div className="flex items-center justify-between p-4 border rounded-lg">
+                  <div className="flex items-center justify-between rounded-lg border p-4">
                     <div>
                       <h3 className="font-medium">
                         {t('subscription.cancellationDate')}
@@ -221,9 +221,9 @@ export default function SubscriptionPage() {
                 )}
 
                 {isSubscriptionOwner && (
-                  <div className="pt-4 border-t space-y-3">
+                  <div className="space-y-3 border-t pt-4">
                     <Button onClick={handleManageBilling} className="w-full">
-                      <ExternalLink className="h-4 w-4 mr-2" />
+                      <ExternalLink className="mr-2 size-4" />
                       {isInTrial
                         ? t('subscription.addPaymentMethod')
                         : t('subscription.manageBilling')}

--- a/src/app/(app)/team/invitation/[invitationId]/page.tsx
+++ b/src/app/(app)/team/invitation/[invitationId]/page.tsx
@@ -214,7 +214,7 @@ export default function InvitationPage() {
         <div className="mx-auto max-w-2xl">
           <Button asChild variant="outline" className="mb-8">
             <Link href="/team">
-              <ArrowLeft className="mr-2 h-4 w-4" />
+              <ArrowLeft className="mr-2 size-4" />
               {t('settings.backToTeam')}
             </Link>
           </Button>
@@ -245,11 +245,11 @@ export default function InvitationPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+    <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
       <div className="mx-auto max-w-2xl">
         <Button asChild variant="outline" className="mb-8">
           <Link href="/team">
-            <ArrowLeft className="mr-2 h-4 w-4" />
+            <ArrowLeft className="mr-2 size-4" />
             {t('settings.backToTeam')}
           </Link>
         </Button>
@@ -257,7 +257,7 @@ export default function InvitationPage() {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Mail className="h-5 w-5" />
+              <Mail className="size-5" />
               {t('teams.teamInvitation')}
             </CardTitle>
             <CardDescription>{invitationHeaderDescription}</CardDescription>
@@ -265,7 +265,7 @@ export default function InvitationPage() {
           <CardContent className="space-y-6">
             {invitation && team && (
               <div className="space-y-4">
-                <div className="rounded-lg border p-4 space-y-3">
+                <div className="space-y-3 rounded-lg border p-4">
                   <div className="flex items-start justify-between">
                     <div className="space-y-1">
                       <p className="text-sm text-muted-foreground">
@@ -280,7 +280,7 @@ export default function InvitationPage() {
                     </div>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-4 pt-3 border-t">
+                  <div className="grid grid-cols-2 gap-4 border-t pt-3">
                     <div className="space-y-1">
                       <p className="text-sm text-muted-foreground">
                         {t('teams.role')}
@@ -297,9 +297,9 @@ export default function InvitationPage() {
                     </div>
                   </div>
 
-                  <div className="pt-3 border-t">
+                  <div className="border-t pt-3">
                     <div className="flex items-center gap-2">
-                      <Clock className="h-4 w-4 text-muted-foreground" />
+                      <Clock className="size-4 text-muted-foreground" />
                       <span className="text-sm text-muted-foreground">
                         {isExpired ? (
                           <span className="text-red-600">
@@ -318,7 +318,7 @@ export default function InvitationPage() {
                 </div>
 
                 {user.email !== invitation.email && (
-                  <div className="rounded-lg border border-amber-500 bg-amber-50 dark:bg-amber-950/20 p-4">
+                  <div className="rounded-lg border border-amber-500 bg-amber-50 p-4 dark:bg-amber-950/20">
                     <p className="text-sm text-amber-800 dark:text-amber-200">
                       {t('teams.invitationEmailWarning', {
                         invitedEmail: invitation.email,
@@ -335,7 +335,7 @@ export default function InvitationPage() {
                       disabled={processing || user.email !== invitation.email}
                       className="flex-1"
                     >
-                      <Check className="mr-2 h-4 w-4" />
+                      <Check className="mr-2 size-4" />
                       {t('teams.acceptInvitation')}
                     </Button>
                     <Button
@@ -344,7 +344,7 @@ export default function InvitationPage() {
                       variant="outline"
                       className="flex-1"
                     >
-                      <X className="mr-2 h-4 w-4" />
+                      <X className="mr-2 size-4" />
                       {t('teams.declineInvitation')}
                     </Button>
                   </div>

--- a/src/app/(app)/team/page.tsx
+++ b/src/app/(app)/team/page.tsx
@@ -257,7 +257,7 @@ export default function TeamPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+    <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
       <div className="mx-auto max-w-4xl">
         {!team ? (
           // No team - show create team option and pending invitations
@@ -265,18 +265,18 @@ export default function TeamPage() {
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                  <Users className="h-5 w-5" />
+                  <Users className="size-5" />
                   {t('teams.title')}
                 </CardTitle>
                 <CardDescription>{t('teams.subtitle')}</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="text-center py-8">
-                  <Users className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                  <h3 className="text-lg font-medium mb-2">
+                <div className="py-8 text-center">
+                  <Users className="mx-auto mb-4 size-12 text-muted-foreground" />
+                  <h3 className="mb-2 text-lg font-medium">
                     {t('teams.noTeamYet')}
                   </h3>
-                  <p className="text-muted-foreground mb-6">
+                  <p className="mb-6 text-muted-foreground">
                     {t('teams.noTeamDescription')}
                   </p>
                   <CreateTeamDialog
@@ -293,7 +293,7 @@ export default function TeamPage() {
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
-                    <Mail className="h-5 w-5" />
+                    <Mail className="size-5" />
                     {t('teams.pendingInvitations')}
                   </CardTitle>
                   <CardDescription>
@@ -323,14 +323,14 @@ export default function TeamPage() {
                       className="flex items-center gap-2"
                       data-testid="team-name"
                     >
-                      <Users className="h-5 w-5" />
+                      <Users className="size-5" />
                       {team.name}
                     </CardTitle>
                     <CardDescription>
                       {team.description || t('teams.noDescriptionProvided')}
                     </CardDescription>
                   </div>
-                  <div className="flex gap-2 flex-col md:flex-row">
+                  <div className="flex flex-col gap-2 md:flex-row">
                     {hasWritePermissions && (
                       <InviteMemberDialog
                         teamId={team.id}
@@ -345,7 +345,7 @@ export default function TeamPage() {
                       onTeamDeleted={handleTeamDeleted}
                     >
                       <Button variant="outline" size="sm">
-                        <Settings className="mr-2 h-4 w-4" />
+                        <Settings className="mr-2 size-4" />
                         {t('teams.settings')}
                       </Button>
                     </TeamSettingsDialog>
@@ -359,46 +359,46 @@ export default function TeamPage() {
               onValueChange={setSelectedTab}
               className="space-y-6"
             >
-              <TabsList className="flex w-full flex-start bg-transparent p-0">
+              <TabsList className="flex w-full items-start justify-start bg-transparent p-0">
                 <TabsTrigger
                   value="members"
-                  className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-transparent flex items-center gap-2"
+                  className="flex items-center gap-2 rounded-none border-b-2 border-transparent text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
                 >
-                  <Users className="h-4 w-4" />
+                  <Users className="size-4" />
                   {t('teams.teamMembers')} ({members.length})
                 </TabsTrigger>
                 {hasWritePermissions && (
                   <TabsTrigger
                     value="invitations"
-                    className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-transparent flex items-center gap-2"
+                    className="flex items-center gap-2 rounded-none border-b-2 border-transparent text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
                   >
-                    <UserPlus className="h-4 w-4" />
+                    <UserPlus className="size-4" />
                     {t('teams.pendingInvitationsTab')} ({invitations.length})
                   </TabsTrigger>
                 )}
                 {hasWritePermissions && (
                   <TabsTrigger
                     value="reports"
-                    className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-transparent flex items-center gap-2"
+                    className="flex items-center gap-2 rounded-none border-b-2 border-transparent text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
                   >
-                    <FileSpreadsheet className="h-4 w-4" />
+                    <FileSpreadsheet className="size-4" />
                     {t('reports.tab')}
                   </TabsTrigger>
                 )}
                 {hasWritePermissions && (
                   <TabsTrigger
                     value="team-settings"
-                    className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-transparent flex items-center gap-2"
+                    className="flex items-center gap-2 rounded-none border-b-2 border-transparent text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
                   >
-                    <SlidersHorizontal className="h-4 w-4" />
+                    <SlidersHorizontal className="size-4" />
                     {t('teams.teamWideSettings')}
                   </TabsTrigger>
                 )}
                 <TabsTrigger
                   value="subscription"
-                  className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-transparent flex items-center gap-2"
+                  className="flex items-center gap-2 rounded-none border-b-2 border-transparent text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
                 >
-                  <CreditCard className="h-4 w-4" />
+                  <CreditCard className="size-4" />
                   {t('teams.subscription')}
                 </TabsTrigger>
               </TabsList>

--- a/src/app/(app)/team/reports/page.tsx
+++ b/src/app/(app)/team/reports/page.tsx
@@ -165,11 +165,11 @@ export default function TeamReportsPage() {
     : null
 
   return (
-    <div className="min-h-screen bg-muted p-4 sm:p-8 pb-20 md:pb-8">
+    <div className="min-h-screen bg-muted p-4 pb-20 sm:p-8 md:pb-8">
       <div className="mx-auto max-w-7xl">
         <Button asChild variant="outline" className="mb-8">
           <Link href="/team">
-            <ArrowLeft className="mr-2 h-4 w-4" />
+            <ArrowLeft className="mr-2 size-4" />
             {t('settings.backToTeam')}
           </Link>
         </Button>
@@ -188,7 +188,7 @@ export default function TeamReportsPage() {
                     }
                     data-testid="reports-previous-month-button"
                   >
-                    <ChevronLeft className="h-4 w-4" />
+                    <ChevronLeft className="size-4" />
                   </Button>
                   <h2
                     className="text-xl font-semibold"
@@ -204,7 +204,7 @@ export default function TeamReportsPage() {
                     }
                     data-testid="reports-next-month-button"
                   >
-                    <ChevronRight className="h-4 w-4" />
+                    <ChevronRight className="size-4" />
                   </Button>
                 </div>
               )}

--- a/src/app/(landing)/cookies/page.tsx
+++ b/src/app/(landing)/cookies/page.tsx
@@ -23,10 +23,10 @@ export default function CookiePolicyPage() {
     language === 'de' ? 'cookie-policy-de-article' : 'cookie-policy-en-article'
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <main className="flex-1 flex flex-col items-center justify-center px-4 py-16">
+    <div className="flex min-h-dvh flex-col">
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <article
-          className="prose prose-neutral dark:prose-invert max-w-2xl w-full bg-white/80 rounded-xl shadow-lg p-6 md:p-10"
+          className="prose w-full max-w-2xl rounded-xl bg-white/80 p-6 shadow-lg prose-neutral md:p-10 dark:prose-invert"
           data-testid={testId}
         >
           <Content />

--- a/src/app/(landing)/features/page.tsx
+++ b/src/app/(landing)/features/page.tsx
@@ -15,7 +15,7 @@ export default function FeaturesPage() {
     <div>
       <div className="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <p className="text-base font-semibold leading-7 text-primary">
+          <p className="text-base leading-7 font-semibold text-primary">
             {t('features.headerTag')}
           </p>
           <h2 className="mt-2 text-4xl font-bold tracking-tight text-foreground sm:text-6xl">
@@ -35,9 +35,9 @@ export default function FeaturesPage() {
           {Array.isArray(features) &&
             features.map((key) => (
               <div key={key} className="relative pl-16">
-                <dt className="text-base font-semibold leading-7 text-foreground">
-                  <div className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg bg-primary">
-                    <Check className="h-6 w-6 text-white" aria-hidden="true" />
+                <dt className="text-base leading-7 font-semibold text-foreground">
+                  <div className="absolute top-0 left-0 flex size-10 items-center justify-center rounded-lg bg-primary">
+                    <Check className="size-6 text-white" aria-hidden="true" />
                   </div>
                   {t(`features.list.${key}.title`)}
                 </dt>
@@ -49,7 +49,7 @@ export default function FeaturesPage() {
         </dl>
       </div>
 
-      <div className="flex my-32 text-center">
+      <div className="my-32 flex text-center">
         <Image
           src="/images/tracker.png"
           alt="Tracker"

--- a/src/app/(landing)/imprint/page.tsx
+++ b/src/app/(landing)/imprint/page.tsx
@@ -18,10 +18,10 @@ export default function ImprintPage() {
   const testId = language === 'de' ? 'imprint-de-article' : 'imprint-en-article'
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <main className="flex-1 flex flex-col items-center justify-center px-4 py-16">
+    <div className="flex min-h-dvh flex-col">
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <article
-          className="prose prose-neutral dark:prose-invert max-w-2xl w-full bg-white/80 rounded-xl shadow-lg p-6 md:p-10"
+          className="prose w-full max-w-2xl rounded-xl bg-white/80 p-6 shadow-lg prose-neutral md:p-10 dark:prose-invert"
           data-testid={testId}
         >
           <Content />

--- a/src/app/(landing)/privacy/page.tsx
+++ b/src/app/(landing)/privacy/page.tsx
@@ -18,10 +18,10 @@ export default function PrivacyPage() {
   const testId = language === 'de' ? 'privacy-de-article' : 'privacy-en-article'
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <main className="flex-1 flex flex-col items-center justify-center px-4 py-16">
+    <div className="flex min-h-dvh flex-col">
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <article
-          className="prose prose-neutral dark:prose-invert max-w-2xl w-full bg-white/80 rounded-xl shadow-lg p-6 md:p-10"
+          className="prose w-full max-w-2xl rounded-xl bg-white/80 p-6 shadow-lg prose-neutral md:p-10 dark:prose-invert"
           data-testid={testId}
         >
           <Content />

--- a/src/app/(landing)/terms/page.tsx
+++ b/src/app/(landing)/terms/page.tsx
@@ -18,10 +18,10 @@ export default function TermsPage() {
   const testId = language === 'de' ? 'terms-de-article' : 'terms-en-article'
 
   return (
-    <div className="min-h-dvh flex flex-col">
-      <main className="flex-1 flex flex-col items-center justify-center px-4 py-16">
+    <div className="flex min-h-dvh flex-col">
+      <main className="flex flex-1 flex-col items-center justify-center px-4 py-16">
         <article
-          className="prose prose-neutral dark:prose-invert max-w-2xl w-full bg-white/80 rounded-xl shadow-lg p-6 md:p-10"
+          className="prose w-full max-w-2xl rounded-xl bg-white/80 p-6 shadow-lg prose-neutral md:p-10 dark:prose-invert"
           data-testid={testId}
         >
           <Content />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -303,9 +303,9 @@ export default function LoginPage() {
   }
 
   return (
-    <ColorfulBackground className="min-h-screen flex flex-col items-center justify-center p-4">
+    <ColorfulBackground className="flex min-h-screen flex-col items-center justify-center p-4">
       <div className="mb-4 flex items-center gap-2">
-        <TimeWiseIcon className="h-8 w-8 text-primary" />
+        <TimeWiseIcon className="size-8 text-primary" />
         <h1 className="font-headline text-3xl font-bold tracking-tight">
           {t('common.appName')} {useMocks ? ' (Test Mode)' : ''}
         </h1>
@@ -320,20 +320,20 @@ export default function LoginPage() {
             <TabsList className="grid w-full grid-cols-2 bg-transparent p-0">
               <TabsTrigger
                 value="signin"
-                className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-gray-200"
+                className="rounded-none border-b-2 border-gray-200 text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
               >
                 {t('login.signInTab')}
               </TabsTrigger>
               <TabsTrigger
                 value="signup"
-                className="text-muted-foreground hover:text-foreground data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none data-[state=active]:border-b-2 data-[state=active]:border-primary rounded-none border-b-2 border-gray-200"
+                className="rounded-none border-b-2 border-gray-200 text-muted-foreground hover:text-foreground data-[state=active]:border-b-2 data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none"
               >
                 {t('login.signUpTab')}
               </TabsTrigger>
             </TabsList>
             <TabsContent value="signin" className="mt-6">
               {buildLoginForm()}
-              <div className="mt-4 pt-4 border-t">
+              <div className="mt-4 border-t pt-4">
                 {useMocks && buildMockLogin()}
               </div>
             </TabsContent>
@@ -400,7 +400,7 @@ export default function LoginPage() {
           onClick={handleGoogleSignIn}
           disabled={loading}
         >
-          <GoogleIcon className="mr-2 h-4 w-4" />
+          <GoogleIcon className="mr-2 size-4" />
           {t('login.signInWithGoogle')}
         </Button>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,14 +16,14 @@ export default async function LandingPage() {
     <LandingLayout>
       {/* Hero Section */}
       <section className="w-full py-12 md:py-24 lg:py-32">
-        <div className="container px-4 md:px-6 mx-auto">
-          <div className="flex w-full gap-6 lg:gap-12 flex-col md:flex-row">
+        <div className="container mx-auto px-4 md:px-6">
+          <div className="flex w-full flex-col gap-6 md:flex-row lg:gap-12">
             <div className="flex flex-shrink flex-col justify-center space-y-4 md:basis-auto">
               <div className="space-y-2">
                 <h1 className="text-3xl font-bold tracking-tighter sm:text-5xl xl:text-6xl/none">
                   {t('landing.heroTitle')}
                 </h1>
-                <p className="max-w-[600px] text-muted-foreground md:text-xl">
+                <p className="max-w-150 text-muted-foreground md:text-xl">
                   {t('landing.heroDescription')}
                 </p>
               </div>
@@ -39,7 +39,7 @@ export default async function LandingPage() {
             {/* Hero Illustration */}
             <div
               className={
-                'flex items-center justify-center lg:order-last p-4 md:basis-2/3'
+                'flex items-center justify-center p-4 md:basis-2/3 lg:order-last'
               }
             >
               <LandingIllustration className="aspect-video text-primary" />

--- a/src/app/protected/page.tsx
+++ b/src/app/protected/page.tsx
@@ -6,12 +6,12 @@ export default function ProtectedPage() {
   return (
     <SubscriptionGuard>
       <div className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold mb-4">Protected Content</h1>
+        <h1 className="mb-4 text-3xl font-bold">Protected Content</h1>
         <p className="text-gray-600">
           This content is only visible to users with an active subscription.
         </p>
-        <div className="mt-8 p-6 bg-green-50 border border-green-200 rounded-lg">
-          <h2 className="text-xl font-semibold text-green-800 mb-2">
+        <div className="mt-8 rounded-lg border border-green-200 bg-green-50 p-6">
+          <h2 className="mb-2 text-xl font-semibold text-green-800">
             Welcome to the Premium Features!
           </h2>
           <p className="text-green-700">

--- a/src/components/__tests__/smart-link.test.tsx
+++ b/src/components/__tests__/smart-link.test.tsx
@@ -68,13 +68,13 @@ describe('SmartLink', () => {
 
     it('applies custom className', () => {
       render(
-        <SmartLink href="/login" className="custom-class">
+        <SmartLink href="/login" className="bg-accent">
           <button>Get Started</button>
         </SmartLink>,
       )
 
       const link = screen.getByRole('link')
-      expect(link).toHaveClass('custom-class')
+      expect(link).toHaveClass('bg-accent')
     })
   })
 
@@ -151,7 +151,7 @@ describe('SmartLink', () => {
       render(
         <SmartLink
           href="/login"
-          className="test-class"
+          className="bg-accent"
           data-testid="smart-link"
           target="_blank"
         >
@@ -160,7 +160,7 @@ describe('SmartLink', () => {
       )
 
       const link = screen.getByTestId('smart-link')
-      expect(link).toHaveClass('test-class')
+      expect(link).toHaveClass('bg-accent')
       expect(link).toHaveAttribute('target', '_blank')
     })
   })

--- a/src/components/__tests__/trial-banner.test.tsx
+++ b/src/components/__tests__/trial-banner.test.tsx
@@ -236,12 +236,12 @@ describe('TrialBanner', () => {
       render(
         <TrialBanner
           subscription={createMockSubscription('trialing')}
-          className="custom-class"
+          className="bg-accent"
         />,
       )
 
       const banner = screen.getByTestId('trial-banner')
-      expect(banner).toHaveClass('custom-class')
+      expect(banner).toHaveClass('bg-accent')
     })
   })
 

--- a/src/components/__tests__/user-menu.test.tsx
+++ b/src/components/__tests__/user-menu.test.tsx
@@ -214,10 +214,10 @@ describe('UserMenu', () => {
     })
 
     it('applies custom className', () => {
-      renderWithTooltipProvider(<UserMenu className="custom-class" />)
+      renderWithTooltipProvider(<UserMenu className="bg-accent" />)
 
       const menuButton = screen.getByRole('button')
-      expect(menuButton).toHaveClass('custom-class')
+      expect(menuButton).toHaveClass('bg-accent')
     })
 
     it('has correct styling for hover effects', () => {

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -30,7 +30,7 @@ export default function AppHeader() {
         className="flex items-center gap-2 hover:opacity-90"
         aria-label={t('common.home')}
       >
-        <TimeWiseIcon className="h-6 w-6 text-primary" />
+        <TimeWiseIcon className="size-6 text-primary" />
         <h1 className="font-headline text-xl font-bold tracking-tight">
           {t('common.appName')}
         </h1>
@@ -63,7 +63,7 @@ export default function AppHeader() {
                 <Link
                   href="/stats"
                   className={cn(
-                    'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-foreground hover:bg-transparent hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 [&_svg]:size-4',
+                    'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-foreground hover:bg-transparent hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none [&_svg]:size-4',
                     pathname === '/stats' && 'font-semibold text-primary',
                   )}
                   aria-current={pathname === '/stats' ? 'page' : undefined}

--- a/src/components/copy-to-date-picker.tsx
+++ b/src/components/copy-to-date-picker.tsx
@@ -57,17 +57,17 @@ export function CopyToDatePicker({
         data-testid="copy-to-date-picker-popover"
       >
         <div className="flex flex-col">
-          {title ? (
-            <div className="border-b px-4 py-3 text-md font-medium">
+          {title && (
+            <div className="border-b px-4 py-3 text-base font-medium">
               {title}
             </div>
-          ) : null}
+          )}
           <Calendar
             mode="single"
             selected={targetDate}
             onSelect={(date) => onTargetDateChange(date ?? undefined)}
           />
-          <div className="flex gap-2 border-t p-4 justify-end">
+          <div className="flex justify-end gap-2 border-t p-4">
             <Button variant="outline" size="sm" onClick={handleCancel}>
               {t('common.cancel')}
             </Button>

--- a/src/components/daily-actions-card.tsx
+++ b/src/components/daily-actions-card.tsx
@@ -36,24 +36,24 @@ const DailyActionsCard: React.FC = () => {
           onClick={() => handleAddSpecialEntry('SICK_LEAVE')}
           variant="outline"
         >
-          <BedDouble className="mr-2 h-4 w-4" />{' '}
+          <BedDouble className="mr-2 size-4" />{' '}
           {t('special_locations.SICK_LEAVE')}
         </Button>
         <Button onClick={() => handleAddSpecialEntry('PTO')} variant="outline">
-          <Plane className="mr-2 h-4 w-4" /> {t('special_locations.PTO')}
+          <Plane className="mr-2 size-4" /> {t('special_locations.PTO')}
         </Button>
         <Button
           onClick={() => handleAddSpecialEntry('BANK_HOLIDAY')}
           variant="outline"
         >
-          <Landmark className="mr-2 h-4 w-4" />{' '}
+          <Landmark className="mr-2 size-4" />{' '}
           {t('special_locations.BANK_HOLIDAY')}
         </Button>
         <Button
           onClick={() => handleAddSpecialEntry('TIME_OFF_IN_LIEU')}
           variant="outline"
         >
-          <Hourglass className="mr-2 h-4 w-4" />{' '}
+          <Hourglass className="mr-2 size-4" />{' '}
           {t('special_locations.TIME_OFF_IN_LIEU')}
         </Button>
       </CardContent>

--- a/src/components/date-navigation.tsx
+++ b/src/components/date-navigation.tsx
@@ -42,7 +42,7 @@ const DateNavigation: React.FC = () => {
       <h2 className="font-headline text-2xl font-bold">
         {t('tracker.timeEntriesTitle')}
       </h2>
-      <div className="flex flex-wrap w-full items-center gap-2 sm:w-auto">
+      <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
         <div className="flex flex-1 items-center gap-1">
           <Button
             variant="outline"
@@ -50,7 +50,7 @@ const DateNavigation: React.FC = () => {
             onClick={handlePreviousDay}
             aria-label="Previous day"
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ChevronLeft className="size-4" />
           </Button>
           <Popover>
             <PopoverTrigger asChild>
@@ -63,7 +63,7 @@ const DateNavigation: React.FC = () => {
                     : undefined
                 }
               >
-                <CalendarIcon className="mr-2 h-4 w-4" />
+                <CalendarIcon className="mr-2 size-4" />
                 {formattedSelectedDate}
               </Button>
             </PopoverTrigger>
@@ -81,13 +81,13 @@ const DateNavigation: React.FC = () => {
             onClick={handleNextDay}
             aria-label="Next day"
           >
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className="size-4" />
           </Button>
         </div>
         <Sheet open={isFormOpen} onOpenChange={setIsFormOpen}>
           <SheetTrigger asChild>
             <SubscriptionGuardButton onClick={openNewEntryForm}>
-              <Plus className="mr-2 h-4 w-4" /> {t('tracker.addEntryButton')}
+              <Plus className="mr-2 size-4" /> {t('tracker.addEntryButton')}
             </SubscriptionGuardButton>
           </SheetTrigger>
           <SheetContent className="flex w-full max-w-none flex-col sm:max-w-md">

--- a/src/components/export-preview-actions.tsx
+++ b/src/components/export-preview-actions.tsx
@@ -76,7 +76,7 @@ export function ExportPreviewActions({
               data-testid="export-preview-export-button"
               disabled={!hasEntries}
             >
-              <Download className="mr-2 h-4 w-4 shrink-0" />
+              <Download className="mr-2 size-4 shrink-0" />
               <span className="truncate">{t('export.exportButton')}</span>
             </Button>
           </span>
@@ -98,7 +98,7 @@ export function ExportPreviewActions({
               data-testid="export-preview-pdf-button"
               disabled={!hasEntries}
             >
-              <Printer className="mr-2 h-4 w-4 shrink-0" />
+              <Printer className="mr-2 size-4 shrink-0" />
               <span className="truncate">{t('export.exportPdfButton')}</span>
             </Button>
           </span>
@@ -121,7 +121,7 @@ export function ExportPreviewActions({
         onClick={!publishedAt ? onPublish : undefined}
         data-testid="export-preview-publish-button"
       >
-        <Send className="mr-2 h-4 w-4 shrink-0" />
+        <Send className="mr-2 size-4 shrink-0" />
         <span className="truncate">
           {publishedAt ? t('export.publishUpdate') : t('export.publish')}
         </span>
@@ -200,7 +200,7 @@ export function ExportPreviewActions({
           className="col-start-3 flex items-center"
           data-testid="export-preview-published-on"
         >
-          <span className="text-muted-foreground text-sm">
+          <span className="text-sm text-muted-foreground">
             {t('export.publishedOn', {
               date: format.dateTime(publishedAt, 'short'),
             })}

--- a/src/components/export-preview.tsx
+++ b/src/components/export-preview.tsx
@@ -238,9 +238,9 @@ export default function ExportPreview() {
         <CardContent className="p-4 sm:p-6">
           <div className="mb-6 flex flex-col items-center justify-between sm:flex-row print:hidden">
             <div className="flex items-center gap-4">
-              <Skeleton className="h-10 w-10" />
+              <Skeleton className="size-10" />
               <Skeleton className="h-8 w-48" />
-              <Skeleton className="h-10 w-10" />
+              <Skeleton className="size-10" />
             </div>
             <Skeleton className="h-10 w-36" />
           </div>
@@ -276,7 +276,7 @@ export default function ExportPreview() {
                 onClick={() => setSelectedMonth(subMonths(selectedMonth, 1))}
                 data-testid="export-preview-previous-month-button"
               >
-                <ChevronLeft className="h-4 w-4" />
+                <ChevronLeft className="size-4" />
               </Button>
               <h2
                 className="text-2xl font-bold"
@@ -290,7 +290,7 @@ export default function ExportPreview() {
                 onClick={() => setSelectedMonth(addMonths(selectedMonth, 1))}
                 data-testid="export-preview-next-month-button"
               >
-                <ChevronRight className="h-4 w-4" />
+                <ChevronRight className="size-4" />
               </Button>
             </div>
             <ExportPreviewActions

--- a/src/components/inputs/password-input.tsx
+++ b/src/components/inputs/password-input.tsx
@@ -40,16 +40,16 @@ function PasswordInputUI({
         type="button"
         variant="ghost"
         size="sm"
-        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent hover:text-primary"
+        className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent hover:text-primary"
         onClick={onToggleVisibility}
         disabled={disabled}
         data-testid={toggleTestId}
         aria-label={showPassword ? 'Hide password' : 'Show password'}
       >
         {showPassword ? (
-          <EyeOff className="h-4 w-4" aria-hidden="true" />
+          <EyeOff className="size-4" aria-hidden="true" />
         ) : (
-          <Eye className="h-4 w-4" aria-hidden="true" />
+          <Eye className="size-4" aria-hidden="true" />
         )}
       </Button>
     </div>

--- a/src/components/install-prompt.tsx
+++ b/src/components/install-prompt.tsx
@@ -100,10 +100,10 @@ export function InstallPrompt() {
         <button
           type="button"
           onClick={() => setDismissed(true)}
-          className="rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring"
+          className="rounded-md p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:outline-none"
           aria-label={t('common.close')}
         >
-          <X className="h-4 w-4" />
+          <X className="size-4" />
         </button>
       </div>
     </div>

--- a/src/components/landing-features-section.tsx
+++ b/src/components/landing-features-section.tsx
@@ -36,7 +36,7 @@ export default function LandingFeaturesSection() {
             <h2 className="text-3xl font-bold tracking-tighter sm:text-5xl">
               {headerTitle}
             </h2>
-            <p className="max-w-[900px] text-muted-foreground md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed">
+            <p className="max-w-225 text-muted-foreground md:text-xl/relaxed lg:text-base/relaxed xl:text-xl/relaxed">
               {headerDescription}
             </p>
           </div>
@@ -47,7 +47,7 @@ export default function LandingFeaturesSection() {
             if (!item?.title || !item?.desc) return null
             return (
               <div key={key} className="flex items-start gap-4">
-                <div className="h-8 w-8 flex-shrink-0 text-primary" />
+                <div className="size-8 shrink-0 text-primary" />
                 <div className="grid gap-1">
                   <h3 className="text-lg font-bold">{item.title}</h3>
                   <p className="text-sm text-muted-foreground">{item.desc}</p>

--- a/src/components/landing-layout.tsx
+++ b/src/components/landing-layout.tsx
@@ -22,7 +22,7 @@ export default function LandingLayout({
     { name: t('nav.top.pricing'), href: '/pricing' },
   ]
   return (
-    <div className="bg-background min-h-dvh flex flex-col">
+    <div className="flex min-h-dvh flex-col bg-background">
       <header className="relative z-50 w-full bg-white/80 backdrop-blur">
         <nav
           className="flex items-center justify-between p-4 lg:px-8"
@@ -30,7 +30,7 @@ export default function LandingLayout({
           data-testid="top-nav"
         >
           <div className="flex items-center gap-3">
-            <Link href="/" className="flex items-center gap-2 group">
+            <Link href="/" className="group flex items-center gap-2">
               <span className="sr-only">{t('common.appName')}</span>
               <TimeWiseIcon className="h-12 w-auto" />
               <span className="text-lg font-bold text-primary group-hover:underline">
@@ -44,7 +44,7 @@ export default function LandingLayout({
               <Link
                 key={item.name}
                 href={item.href}
-                className="text-sm font-semibold leading-6 text-foreground"
+                className="text-sm leading-6 font-semibold text-foreground"
               >
                 {item.name}
               </Link>
@@ -56,7 +56,7 @@ export default function LandingLayout({
           </div>
         </nav>
       </header>
-      <ColorfulBackground className="flex-1 flex flex-col">
+      <ColorfulBackground className="flex flex-1 flex-col">
         <InstallPrompt />
         {children}
       </ColorfulBackground>

--- a/src/components/location-input.tsx
+++ b/src/components/location-input.tsx
@@ -120,12 +120,12 @@ export const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
                 onClick={onGetCurrentLocation}
                 aria-label="Get current location"
                 disabled={isFetchingLocation}
-                className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6"
+                className="absolute top-1/2 right-2 size-6 -translate-y-1/2"
               >
                 {isFetchingLocation ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                 ) : (
-                  <MapPin className="h-4 w-4" />
+                  <MapPin className="size-4" />
                 )}
               </Button>
             </TooltipTrigger>
@@ -138,7 +138,7 @@ export const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
           <div
             id="location-suggestion-list"
             role="listbox"
-            className="absolute left-0 top-full mt-1 w-full bg-popover border border-border rounded shadow-lg z-20"
+            className="absolute top-full left-0 z-20 mt-1 w-full rounded border border-border bg-popover shadow-lg"
             style={{ minWidth: '100%' }}
           >
             {suggestions.map((suggestion, i) => (
@@ -148,7 +148,7 @@ export const LocationInput = forwardRef<HTMLInputElement, LocationInputProps>(
                 id={`location-suggestion-${i}`}
                 role="option"
                 aria-selected={activeSuggestion === i}
-                className={`w-full text-left px-3 py-2 text-sm hover:bg-accent focus:bg-accent border-0 bg-transparent ${
+                className={`w-full border-0 bg-transparent px-3 py-2 text-left text-sm hover:bg-accent focus:bg-accent ${
                   activeSuggestion === i ? 'bg-accent text-primary' : ''
                 }`}
                 onMouseDown={(e) => {

--- a/src/components/locked-by-team-alert.tsx
+++ b/src/components/locked-by-team-alert.tsx
@@ -18,7 +18,7 @@ export function LockedByTeamAlert({
   const t = useTranslations()
   return (
     <Alert variant="warning" className="mb-4">
-      <AlertTriangle className="h-4 w-4" aria-hidden />
+      <AlertTriangle className="size-4" aria-hidden />
       <AlertDescription>
         <span>{message ?? t('settings.managedByTeam')}</span>
         {!showChangeText ? (

--- a/src/components/password-change-dialog.tsx
+++ b/src/components/password-change-dialog.tsx
@@ -264,7 +264,7 @@ export default function PasswordChangeDialog({
               >
                 {isUpdating ? (
                   <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    <Loader2 className="mr-2 size-4 animate-spin" />
                     {t('common.updating')}
                   </>
                 ) : (

--- a/src/components/pricing-section.tsx
+++ b/src/components/pricing-section.tsx
@@ -138,9 +138,9 @@ export default function PricingSection({
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         {/* Header */}
         {showHeader && (
-          <div className="mx-auto max-w-2xl text-center mb-12">
+          <div className="mx-auto mb-12 max-w-2xl text-center">
             <h2
-              className={`ext-3xl font-bold tracking-tight text-foreground sm:text-4xl mb-4 ${
+              className={`mb-4 text-3xl font-bold tracking-tight text-foreground sm:text-4xl ${
                 variant === 'landing' ? 'md:text-5xl' : ''
               }`}
             >
@@ -170,7 +170,7 @@ export default function PricingSection({
             </div>
           ) : (
             <div
-              className={`grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-${Math.min(filteredPlans.length, 4)}`}
+              className={`grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-${Math.min(filteredPlans.length, 4)}`}
             >
               {filteredPlans.map((plan: PricingPlan) => (
                 <div key={plan.id} id={`plan-${plan.id}`}>

--- a/src/components/pricing/billing-toggle.tsx
+++ b/src/components/pricing/billing-toggle.tsx
@@ -20,7 +20,7 @@ export default function BillingToggle({
   const t = useTranslations('landing')
 
   return (
-    <div className="flex justify-center items-center space-x-4 mb-8">
+    <div className="mb-8 flex items-center justify-center space-x-4">
       <Label
         htmlFor="billing-toggle"
         className="text-sm font-medium text-gray-700"

--- a/src/components/pricing/pricing-card.tsx
+++ b/src/components/pricing/pricing-card.tsx
@@ -34,10 +34,10 @@ export default function PricingCard({
   const format = useFormatter()
 
   const renderFeatureIcon = (feature: string) => {
-    if (feature.includes('support')) return <Star className="h-4 w-4" />
+    if (feature.includes('support')) return <Star className="size-4" />
     if (feature.includes('team') || feature.includes('collaboration'))
-      return <Users className="h-4 w-4" />
-    return <Check className="h-4 w-4" />
+      return <Users className="size-4" />
+    return <Check className="size-4" />
   }
 
   const isIndividualPlan = !plan.maxUsers
@@ -46,7 +46,7 @@ export default function PricingCard({
   if (loading === plan.id) {
     subscribeButtonInner = (
       <div className="flex items-center space-x-2">
-        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+        <div className="size-4 animate-spin rounded-full border-b-2 border-white"></div>
         <span>{t('pricing.processing')}</span>
       </div>
     )
@@ -60,12 +60,12 @@ export default function PricingCard({
     <Card
       className={`relative ${
         plan.features.includes('Priority support')
-          ? 'border-2 border-primary shadow-lg scale-105'
+          ? 'scale-105 border-2 border-primary shadow-lg'
           : 'border border-gray-200'
       }`}
     >
       {plan.features.includes('Priority support') && (
-        <div className="absolute -top-3 left-1/2 transform -translate-x-1/2">
+        <div className="absolute -top-3 left-1/2 -translate-x-1/2 transform">
           <Badge className="bg-primary text-primary-foreground">
             {t('pricing.mostPopular')}
           </Badge>
@@ -77,7 +77,7 @@ export default function PricingCard({
         <div className="mt-4">
           {plan.tieredPricing ? (
             <div className="text-center">
-              <div className="text-sm text-gray-600 mb-1">
+              <div className="mb-1 text-sm text-gray-600">
                 {t('pricing.startingAt')}
               </div>
               <div className="text-3xl font-bold text-gray-900">
@@ -89,7 +89,7 @@ export default function PricingCard({
                   },
                 )}
               </div>
-              <div className="text-sm text-gray-600 mt-1">
+              <div className="mt-1 text-sm text-gray-600">
                 {plan.interval === 'month'
                   ? t('pricing.perUserPerMonth')
                   : t('pricing.perUserPerYear')}
@@ -103,7 +103,7 @@ export default function PricingCard({
                   style: 'currency',
                 })}
               </span>
-              <span className="text-gray-600 ml-1">
+              <span className="ml-1 text-gray-600">
                 /
                 {plan.interval === 'month'
                   ? t('pricing.month')
@@ -113,7 +113,7 @@ export default function PricingCard({
           )}
         </div>
         {plan.tieredPricing && plan.tieredPricing.length > 1 && (
-          <p className="text-sm text-gray-500 mt-2">
+          <p className="mt-2 text-sm text-gray-500">
             {t('pricing.tieredHint')}
           </p>
         )}
@@ -132,7 +132,7 @@ export default function PricingCard({
         <ul className="space-y-3">
           {plan.features.map((feature, index) => (
             <li key={index} className="flex items-start space-x-3">
-              <div className="flex-shrink-0 mt-0.5">
+              <div className="mt-0.5 flex-shrink-0">
                 {renderFeatureIcon(feature)}
               </div>
               <span className="text-sm text-gray-700">{feature}</span>

--- a/src/components/pricing/pricing-faq.tsx
+++ b/src/components/pricing/pricing-faq.tsx
@@ -9,30 +9,30 @@ export default function PricingFAQ() {
 
   return (
     <div className="mt-16 text-center">
-      <h3 className="text-3xl font-bold text-gray-900 mb-8">
+      <h3 className="mb-8 text-3xl font-bold text-gray-900">
         {t('pricing.faqTitle')}
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+      <div className="mx-auto grid max-w-4xl grid-cols-1 gap-8 md:grid-cols-2">
         <div className="text-left">
-          <h4 className="text-lg font-semibold text-gray-900 mb-2">
+          <h4 className="mb-2 text-lg font-semibold text-gray-900">
             {t('pricing.faq1Question')}
           </h4>
           <p className="text-gray-600">{t('pricing.faq1Answer')}</p>
         </div>
         <div className="text-left">
-          <h4 className="text-lg font-semibold text-gray-900 mb-2">
+          <h4 className="mb-2 text-lg font-semibold text-gray-900">
             {t('pricing.faq2Question')}
           </h4>
           <p className="text-gray-600">{t('pricing.faq2Answer')}</p>
         </div>
         <div className="text-left">
-          <h4 className="text-lg font-semibold text-gray-900 mb-2">
+          <h4 className="mb-2 text-lg font-semibold text-gray-900">
             {t('pricing.faq3Question')}
           </h4>
           <p className="text-gray-600">{t('pricing.faq3Answer')}</p>
         </div>
         <div className="text-left">
-          <h4 className="text-lg font-semibold text-gray-900 mb-2">
+          <h4 className="mb-2 text-lg font-semibold text-gray-900">
             {t('pricing.faq4Question')}
           </h4>
           <p className="text-gray-600">{t('pricing.faq4Answer')}</p>

--- a/src/components/security/delete-account-card.tsx
+++ b/src/components/security/delete-account-card.tsx
@@ -178,7 +178,7 @@ export function DeleteAccountCard({ user }: DeleteAccountCardProps) {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-destructive">
-          <AlertTriangle className="h-5 w-5" />
+          <AlertTriangle className="size-5" />
           {t('settings.dangerZone')}
         </CardTitle>
         <CardDescription>{t('settings.dangerZoneDescription')}</CardDescription>
@@ -203,7 +203,7 @@ export function DeleteAccountCard({ user }: DeleteAccountCardProps) {
                 size="sm"
                 data-testid="delete-user-button"
               >
-                <Trash2 className="mr-2 h-4 w-4" />
+                <Trash2 className="mr-2 size-4" />
                 {t('settings.deleteAccount')}
               </Button>
             </AlertDialogTrigger>
@@ -242,14 +242,14 @@ export function DeleteAccountCard({ user }: DeleteAccountCardProps) {
                         type="button"
                         variant="ghost"
                         size="sm"
-                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                        className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
                         onClick={() => setShowPassword(!showPassword)}
                         disabled={isDeleting}
                       >
                         {showPassword ? (
-                          <EyeOff className="h-4 w-4" />
+                          <EyeOff className="size-4" />
                         ) : (
-                          <Eye className="h-4 w-4" />
+                          <Eye className="size-4" />
                         )}
                       </Button>
                     </div>
@@ -310,12 +310,12 @@ export function DeleteAccountCard({ user }: DeleteAccountCardProps) {
                 >
                   {isDeleting ? (
                     <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <Loader2 className="mr-2 size-4 animate-spin" />
                       {t('settings.deleteAccountProcessing')}
                     </>
                   ) : (
                     <>
-                      <Trash2 className="mr-2 h-4 w-4" />
+                      <Trash2 className="mr-2 size-4" />
                       {t('settings.deleteAccountConfirmButton')}
                     </>
                   )}

--- a/src/components/stats-view.tsx
+++ b/src/components/stats-view.tsx
@@ -3,9 +3,14 @@
 import { useCallback, useMemo, useState } from 'react'
 
 import {
+  differenceInCalendarDays,
+  endOfDay,
   endOfMonth,
   endOfWeek,
   endOfYear,
+  format,
+  parse,
+  startOfDay,
   startOfMonth,
   startOfWeek,
   startOfYear,
@@ -15,6 +20,8 @@ import {
 import { useTranslations } from 'next-intl'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
@@ -49,6 +56,10 @@ export type StatsPeriod =
   | 'lastMonth'
   | 'thisYear'
 
+type PeriodOption = StatsPeriod | 'custom'
+
+const MAX_RANGE_DAYS = 365
+
 function getPeriodBounds(
   period: StatsPeriod,
   ref: Date,
@@ -80,11 +91,23 @@ function getPeriodBounds(
   }
 }
 
+function parseDateInput(value: string): Date | null {
+  const parsed = parse(value, 'yyyy-MM-dd', new Date())
+  if (isNaN(parsed.getTime())) return null
+  return parsed
+}
+
 export default function StatsView() {
   const t = useTranslations('stats')
   const tSpecial = useTranslations('special_locations')
   const { entries, userSettings, isLoading } = useTimeTrackerContext()
-  const [period, setPeriod] = useState<StatsPeriod>('thisMonth')
+  const [period, setPeriod] = useState<PeriodOption>('thisMonth')
+  const [customStart, setCustomStart] = useState<Date>(() =>
+    startOfDay(startOfMonth(new Date())),
+  )
+  const [customEnd, setCustomEnd] = useState<Date>(() =>
+    endOfDay(endOfMonth(new Date())),
+  )
 
   const getLocationDisplayName = useCallback(
     (location: string) => {
@@ -96,19 +119,46 @@ export default function StatsView() {
     [tSpecial],
   )
 
-  const { start, end } = useMemo(
-    () => getPeriodBounds(period, new Date()),
-    [period],
-  )
+  const { start, end } = useMemo(() => {
+    if (period === 'custom') {
+      return { start: startOfDay(customStart), end: endOfDay(customEnd) }
+    }
+    return getPeriodBounds(period, new Date())
+  }, [period, customStart, customEnd])
+
+  const handleStartChange = (value: string) => {
+    const date = parseDateInput(value)
+    if (!date) return
+    setCustomStart(startOfDay(date))
+    setPeriod('custom')
+  }
+
+  const handleEndChange = (value: string) => {
+    const date = parseDateInput(value)
+    if (!date) return
+    setCustomEnd(endOfDay(date))
+    setPeriod('custom')
+  }
+
+  const rangeError = useMemo(() => {
+    if (customStart > customEnd) {
+      return t('rangeError')
+    }
+    if (differenceInCalendarDays(customEnd, customStart) > MAX_RANGE_DAYS) {
+      return t('rangeError')
+    }
+    return null
+  }, [customStart, customEnd, t])
 
   const entriesInPeriod = useMemo(() => {
+    if (rangeError) return []
     return entries.filter(
       (entry) =>
         entry.startTime &&
         entry.startTime.getTime() >= start.getTime() &&
         entry.startTime.getTime() <= end.getTime(),
     )
-  }, [entries, start, end])
+  }, [entries, start, end, rangeError])
 
   const driverComp = userSettings?.driverCompensationPercent ?? 100
   const passengerComp = userSettings?.passengerCompensationPercent ?? 100
@@ -202,7 +252,7 @@ export default function StatsView() {
   )
 
   const expectedHoursForPeriod = useMemo(() => {
-    if (!userSettings) return 0
+    if (!userSettings) return null
     const expectedMonthly = calculateExpectedMonthlyHours(userSettings)
     switch (period) {
       case 'thisWeek':
@@ -213,14 +263,16 @@ export default function StatsView() {
         return expectedMonthly
       case 'thisYear':
         return expectedMonthly * 12
+      case 'custom':
+        return null
     }
   }, [userSettings, period])
 
-  const overtimeHours = totals.totalHours - expectedHoursForPeriod
-  const showExpectedAndOvertime =
-    !!userSettings &&
-    (userSettings.expectedMonthlyHours != null ||
-      userSettings.defaultWorkHours != null)
+  const overtimeHours =
+    expectedHoursForPeriod !== null
+      ? totals.totalHours - expectedHoursForPeriod
+      : 0
+  const showExpectedAndOvertime = expectedHoursForPeriod !== null
 
   const projectRows = useMemo(
     () =>
@@ -309,168 +361,207 @@ export default function StatsView() {
 
   return (
     <Card>
-      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <CardTitle>{t('title')}</CardTitle>
-        <Select
-          value={period}
-          onValueChange={(v) => setPeriod(v as StatsPeriod)}
-        >
-          <SelectTrigger
-            className="w-full sm:w-[180px]"
-            aria-label={t('title')}
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-end">
+          {period === 'custom' && (
+            <div className="grid w-full grid-cols-2 gap-3 sm:w-auto">
+              <div className="flex flex-col gap-1">
+                <Label
+                  htmlFor="stats-start-date"
+                  className="text-xs text-muted-foreground"
+                >
+                  {t('startDate')}
+                </Label>
+                <Input
+                  id="stats-start-date"
+                  type="date"
+                  value={format(customStart, 'yyyy-MM-dd')}
+                  onChange={(e) => handleStartChange(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <Label
+                  htmlFor="stats-end-date"
+                  className="text-xs text-muted-foreground"
+                >
+                  {t('endDate')}
+                </Label>
+                <Input
+                  id="stats-end-date"
+                  type="date"
+                  value={format(customEnd, 'yyyy-MM-dd')}
+                  onChange={(e) => handleEndChange(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          <Select
+            value={period}
+            onValueChange={(v) => setPeriod(v as PeriodOption)}
           >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="thisWeek">{t('periodThisWeek')}</SelectItem>
-            <SelectItem value="lastWeek">{t('periodLastWeek')}</SelectItem>
-            <SelectItem value="thisMonth">{t('periodThisMonth')}</SelectItem>
-            <SelectItem value="lastMonth">{t('periodLastMonth')}</SelectItem>
-            <SelectItem value="thisYear">{t('periodThisYear')}</SelectItem>
-          </SelectContent>
-        </Select>
+            <SelectTrigger className="w-full sm:w-45" aria-label={t('title')}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="thisWeek">{t('periodThisWeek')}</SelectItem>
+              <SelectItem value="lastWeek">{t('periodLastWeek')}</SelectItem>
+              <SelectItem value="thisMonth">{t('periodThisMonth')}</SelectItem>
+              <SelectItem value="lastMonth">{t('periodLastMonth')}</SelectItem>
+              <SelectItem value="thisYear">{t('periodThisYear')}</SelectItem>
+              <SelectItem value="custom">{t('periodCustom')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </CardHeader>
       <CardContent>
-        <div className="space-y-6">
-          <section
-            className="rounded-lg border bg-muted/30 p-4"
-            aria-labelledby="stats-summary-heading"
-          >
-            <h2
-              id="stats-summary-heading"
-              className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide"
+        {!rangeError ? (
+          <div className="space-y-6">
+            <section
+              className="rounded-lg border bg-muted/30 p-4"
+              aria-labelledby="stats-summary-heading"
             >
-              {t('summaryTitle')}
-            </h2>
-            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
-              {showExpectedAndOvertime && (
-                <>
-                  <dt className="text-muted-foreground">
-                    {t('summaryExpectedHours')}
-                  </dt>
-                  <dd className="tabular-nums font-medium">
-                    {expectedHoursForPeriod.toFixed(1)} h
-                  </dd>
-                </>
-              )}
-              <dt className="text-muted-foreground">
-                {t('summaryTotalHours')}
-              </dt>
-              <dd className="tabular-nums font-medium">
-                {totals.totalHours.toFixed(1)} h
-              </dd>
-              {showExpectedAndOvertime && (
-                <>
-                  <dt className="text-muted-foreground">
-                    {t('summaryOvertime')}
-                  </dt>
-                  <dd className="tabular-nums font-medium">
-                    {overtimeHours >= 0 ? '+' : ''}
-                    {overtimeHours.toFixed(1)} h
-                  </dd>
-                </>
-              )}
-              <dt className="text-muted-foreground">
-                {tSpecial('SICK_LEAVE')}
-              </dt>
-              <dd className="tabular-nums font-medium">
-                {specialTotals.sickLeaveHours.toFixed(1)} h
-              </dd>
-              <dt className="text-muted-foreground">{tSpecial('PTO')}</dt>
-              <dd className="tabular-nums font-medium">
-                {specialTotals.ptoHours.toFixed(1)} h
-              </dd>
-              <dt className="text-muted-foreground">
-                {tSpecial('BANK_HOLIDAY')}
-              </dt>
-              <dd className="tabular-nums font-medium">
-                {specialTotals.holidayHours.toFixed(1)} h
-              </dd>
-              <dt className="text-muted-foreground">
-                {tSpecial('TIME_OFF_IN_LIEU')}
-              </dt>
-              <dd className="tabular-nums font-medium">
-                {specialTotals.timeOffInLieuHours.toFixed(1)} h
-              </dd>
-            </dl>
-          </section>
-
-          {!hasAnyData ? (
-            <p className="text-muted-foreground text-sm">{t('noData')}</p>
-          ) : (
-            <section aria-labelledby="stats-projects-heading">
               <h2
-                id="stats-projects-heading"
-                className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide"
+                id="stats-summary-heading"
+                className="mb-3 text-sm font-semibold tracking-wide text-muted-foreground uppercase"
               >
-                {t('sectionProjects')}
+                {t('summaryTitle')}
               </h2>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>{t('project')}</TableHead>
-                    <TableHead className="text-right">
-                      {t('hoursWorked')}
-                    </TableHead>
-                    <TableHead className="text-right">
-                      {t('hoursDriven')}
-                    </TableHead>
-                    <TableHead className="text-right">
-                      {t('hoursPassenger')}
-                    </TableHead>
-                    <TableHead className="text-right">{t('total')}</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {projectRows.map(
-                    ({
-                      location,
-                      workHours,
-                      driverHours,
-                      passengerHours,
-                      totalHours,
-                    }) => (
-                      <TableRow key={location}>
-                        <TableCell>
-                          {getLocationDisplayName(location)}
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          {workHours.toFixed(1)} h
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          {driverHours.toFixed(1)} h
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          {passengerHours.toFixed(1)} h
-                        </TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          {totalHours.toFixed(1)} h
-                        </TableCell>
-                      </TableRow>
-                    ),
-                  )}
-                </TableBody>
-                <TableFooter>
-                  <TableRow>
-                    <TableCell className="font-medium">{t('total')}</TableCell>
-                    <TableCell className="text-right tabular-nums font-medium">
-                      {projectTotals.workHours.toFixed(1)} h
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums font-medium">
-                      {projectTotals.driverHours.toFixed(1)} h
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums font-medium">
-                      {projectTotals.passengerHours.toFixed(1)} h
-                    </TableCell>
-                    <TableCell className="text-right tabular-nums font-medium">
-                      {projectTotals.totalHours.toFixed(1)} h
-                    </TableCell>
-                  </TableRow>
-                </TableFooter>
-              </Table>
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
+                {showExpectedAndOvertime && (
+                  <>
+                    <dt className="text-muted-foreground">
+                      {t('summaryExpectedHours')}
+                    </dt>
+                    <dd className="font-medium tabular-nums">
+                      {expectedHoursForPeriod.toFixed(1)} h
+                    </dd>
+                  </>
+                )}
+                <dt className="text-muted-foreground">
+                  {t('summaryTotalHours')}
+                </dt>
+                <dd className="font-medium tabular-nums">
+                  {totals.totalHours.toFixed(1)} h
+                </dd>
+                {showExpectedAndOvertime && (
+                  <>
+                    <dt className="text-muted-foreground">
+                      {t('summaryOvertime')}
+                    </dt>
+                    <dd className="font-medium tabular-nums">
+                      {overtimeHours >= 0 ? '+' : ''}
+                      {overtimeHours.toFixed(1)} h
+                    </dd>
+                  </>
+                )}
+                <dt className="text-muted-foreground">
+                  {tSpecial('SICK_LEAVE')}
+                </dt>
+                <dd className="font-medium tabular-nums">
+                  {specialTotals.sickLeaveHours.toFixed(1)} h
+                </dd>
+                <dt className="text-muted-foreground">{tSpecial('PTO')}</dt>
+                <dd className="font-medium tabular-nums">
+                  {specialTotals.ptoHours.toFixed(1)} h
+                </dd>
+                <dt className="text-muted-foreground">
+                  {tSpecial('BANK_HOLIDAY')}
+                </dt>
+                <dd className="font-medium tabular-nums">
+                  {specialTotals.holidayHours.toFixed(1)} h
+                </dd>
+                <dt className="text-muted-foreground">
+                  {tSpecial('TIME_OFF_IN_LIEU')}
+                </dt>
+                <dd className="font-medium tabular-nums">
+                  {specialTotals.timeOffInLieuHours.toFixed(1)} h
+                </dd>
+              </dl>
             </section>
-          )}
-        </div>
+
+            {!hasAnyData ? (
+              <p className="text-sm text-muted-foreground">{t('noData')}</p>
+            ) : (
+              <section aria-labelledby="stats-projects-heading">
+                <h2
+                  id="stats-projects-heading"
+                  className="mb-3 text-sm font-semibold tracking-wide text-muted-foreground uppercase"
+                >
+                  {t('sectionProjects')}
+                </h2>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{t('project')}</TableHead>
+                      <TableHead className="text-right">
+                        {t('hoursWorked')}
+                      </TableHead>
+                      <TableHead className="text-right">
+                        {t('hoursDriven')}
+                      </TableHead>
+                      <TableHead className="text-right">
+                        {t('hoursPassenger')}
+                      </TableHead>
+                      <TableHead className="text-right">{t('total')}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {projectRows.map(
+                      ({
+                        location,
+                        workHours,
+                        driverHours,
+                        passengerHours,
+                        totalHours,
+                      }) => (
+                        <TableRow key={location}>
+                          <TableCell>
+                            {getLocationDisplayName(location)}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {workHours.toFixed(1)} h
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {driverHours.toFixed(1)} h
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {passengerHours.toFixed(1)} h
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {totalHours.toFixed(1)} h
+                          </TableCell>
+                        </TableRow>
+                      ),
+                    )}
+                  </TableBody>
+                  <TableFooter>
+                    <TableRow>
+                      <TableCell className="font-medium">
+                        {t('total')}
+                      </TableCell>
+                      <TableCell className="text-right font-medium tabular-nums">
+                        {projectTotals.workHours.toFixed(1)} h
+                      </TableCell>
+                      <TableCell className="text-right font-medium tabular-nums">
+                        {projectTotals.driverHours.toFixed(1)} h
+                      </TableCell>
+                      <TableCell className="text-right font-medium tabular-nums">
+                        {projectTotals.passengerHours.toFixed(1)} h
+                      </TableCell>
+                      <TableCell className="text-right font-medium tabular-nums">
+                        {projectTotals.totalHours.toFixed(1)} h
+                      </TableCell>
+                    </TableRow>
+                  </TableFooter>
+                </Table>
+              </section>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-destructive">{rangeError}</p>
+        )}
       </CardContent>
     </Card>
   )

--- a/src/components/subscription-guard.tsx
+++ b/src/components/subscription-guard.tsx
@@ -47,7 +47,7 @@ function SubscriptionFallback({
                 aria-label={t('common.back')}
               >
                 <Link href="/">
-                  <ArrowLeft className="h-4 w-4" />
+                  <ArrowLeft className="size-4" />
                 </Link>
               </Button>
               <CardTitle>{t('subscription.loginRequiredTitle')}</CardTitle>
@@ -70,7 +70,7 @@ function SubscriptionFallback({
   }
   // type === 'subscription'
   return (
-    <div className="flex mt-24 items-center justify-center bg-background">
+    <div className="mt-24 flex items-center justify-center bg-background">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle>{t('subscription.requiredTitle')}</CardTitle>
@@ -78,7 +78,7 @@ function SubscriptionFallback({
             {t('subscription.requiredDescription')}
           </CardDescription>
         </CardHeader>
-        <CardContent className="text-center space-y-4">
+        <CardContent className="space-y-4 text-center">
           <Button
             onClick={() => (window.location.href = '/pricing')}
             className="w-full"

--- a/src/components/summary-card.tsx
+++ b/src/components/summary-card.tsx
@@ -22,7 +22,7 @@ const SummaryCard: React.FC = () => {
     <Card className="shadow-lg" data-testid="summary-card">
       <CardHeader>
         <div className="flex items-center gap-2">
-          <BarChart className="h-5 w-5 text-primary" />
+          <BarChart className="size-5 text-primary" />
           <CardTitle>{t('tracker.summaryTitle')}</CardTitle>
         </div>
         <CardDescription>{t('tracker.summaryDescription')}</CardDescription>

--- a/src/components/team/create-team-dialog.tsx
+++ b/src/components/team/create-team-dialog.tsx
@@ -115,7 +115,7 @@ export function CreateTeamDialog({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button>
-          <Plus className="mr-2 h-4 w-4" />
+          <Plus className="mr-2 size-4" />
           {t('teams.createTeam')}
         </Button>
       </DialogTrigger>

--- a/src/components/team/invite-member-dialog.tsx
+++ b/src/components/team/invite-member-dialog.tsx
@@ -125,7 +125,7 @@ export function InviteMemberDialog({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
-          <UserPlus className="mr-2 h-4 w-4" />
+          <UserPlus className="mr-2 size-4" />
           {t('teams.inviteMember')}
         </Button>
       </DialogTrigger>

--- a/src/components/team/link-team-subscription-dialog.tsx
+++ b/src/components/team/link-team-subscription-dialog.tsx
@@ -231,7 +231,7 @@ export function LinkTeamSubscriptionDialog({
       <div className="space-y-4">
         {selected?.status === 'past_due' && (
           <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
-            <AlertCircle className="mt-0.5 h-4 w-4 text-destructive" />
+            <AlertCircle className="mt-0.5 size-4 text-destructive" />
             <div className="text-destructive">
               {t('teams.subscriptionPastDueWarning')}
             </div>
@@ -283,7 +283,7 @@ export function LinkTeamSubscriptionDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <CreditCard className="h-5 w-5" />
+            <CreditCard className="size-5" />
             {t('teams.linkExistingSubscription')}
           </DialogTitle>
           <DialogDescription>

--- a/src/components/team/member-report-table-row.tsx
+++ b/src/components/team/member-report-table-row.tsx
@@ -19,7 +19,7 @@ function MemberReportMetricCell({
 }) {
   const t = useTranslations()
   if (summary.isLoading) {
-    return <Skeleton className="h-4 w-16 ml-auto" />
+    return <Skeleton className="ml-auto h-4 w-16" />
   }
   if (!summary.isPublished) {
     return t('reports.notPublished')

--- a/src/components/team/seat-assignment-dialog.tsx
+++ b/src/components/team/seat-assignment-dialog.tsx
@@ -167,7 +167,7 @@ export function SeatAssignmentDialog({
           onClick={() => handleAssignSeat(member.id)}
           disabled={loadingMemberId === member.id || availableSeats <= 0}
         >
-          <Check className="mr-1 h-3 w-3" />
+          <Check className="mr-1 size-3" />
           {t('teams.assignSeat')}
         </Button>
       )
@@ -181,7 +181,7 @@ export function SeatAssignmentDialog({
           disabled={loadingMemberId === member.id}
           className="text-red-600 hover:text-red-700"
         >
-          <X className="mr-1 h-3 w-3" />
+          <X className="mr-1 size-3" />
           {t('teams.unassignSeat')}
         </Button>
       )
@@ -198,7 +198,7 @@ export function SeatAssignmentDialog({
       <DialogContent className="max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Users className="h-5 w-5" />
+            <Users className="size-5" />
             {t('teams.seatAssignment')}
           </DialogTitle>
           <DialogDescription>
@@ -208,7 +208,7 @@ export function SeatAssignmentDialog({
 
         <div className="space-y-4">
           {/* Seat Usage Summary */}
-          <div className="flex items-center justify-between p-4 bg-muted rounded-lg">
+          <div className="flex items-center justify-between rounded-lg bg-muted p-4">
             <div className="flex items-center gap-4">
               <div className="text-center">
                 <div className="text-2xl font-bold text-primary">
@@ -249,9 +249,7 @@ export function SeatAssignmentDialog({
                   <TableHead>{t('teams.role')}</TableHead>
                   <TableHead>{t('teams.seatStatus')}</TableHead>
                   <TableHead>{t('teams.assignedDate')}</TableHead>
-                  <TableHead className="w-[120px]">
-                    {t('teams.actions')}
-                  </TableHead>
+                  <TableHead className="w-30">{t('teams.actions')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -270,7 +268,7 @@ export function SeatAssignmentDialog({
                     <TableCell>
                       {hasSeatAssigned(member) ? (
                         <Badge className="bg-green-100 text-green-800 hover:bg-green-100">
-                          <Check className="mr-1 h-3 w-3" />
+                          <Check className="mr-1 size-3" />
                           {t('teams.seatAssigned')}
                         </Badge>
                       ) : (

--- a/src/components/team/team-invitations-list.tsx
+++ b/src/components/team/team-invitations-list.tsx
@@ -130,7 +130,7 @@ export function TeamInvitationsList({
 
   if (invitations.length === 0) {
     return (
-      <div className="text-center py-6 text-muted-foreground">
+      <div className="py-6 text-center text-muted-foreground">
         {t('teams.noPendingInvitations')}
       </div>
     )
@@ -156,14 +156,14 @@ export function TeamInvitationsList({
               <TableRow key={invitation.id}>
                 <TableCell>
                   <div className="flex items-center gap-2">
-                    <Mail className="h-4 w-4 text-muted-foreground" />
+                    <Mail className="size-4 text-muted-foreground" />
                     <span className="font-medium">{invitation.email}</span>
                   </div>
                 </TableCell>
                 <TableCell>{getRoleLabel(invitation.role)}</TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2">
-                    <Clock className="h-4 w-4 text-amber-500" />
+                    <Clock className="size-4 text-amber-500" />
                     <span
                       className={expired ? 'text-red-600' : 'text-amber-600'}
                     >
@@ -179,24 +179,24 @@ export function TeamInvitationsList({
                     <DropdownMenuTrigger asChild>
                       <Button
                         variant="ghost"
-                        className="h-8 w-8 p-0"
+                        className="size-8 p-0"
                         disabled={loadingInvitationId === invitation.id}
                       >
-                        <MoreHorizontal className="h-4 w-4" />
+                        <MoreHorizontal className="size-4" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem
                         onClick={() => handleResendInvitation(invitation)}
                       >
-                        <Mail className="mr-2 h-4 w-4" />
+                        <Mail className="mr-2 size-4" />
                         {t('teams.resendInvitation')}
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         className="text-red-600"
                         onClick={() => handleCancelInvitation(invitation.id)}
                       >
-                        <X className="mr-2 h-4 w-4" />
+                        <X className="mr-2 size-4" />
                         {t('teams.cancelInvitation')}
                       </DropdownMenuItem>
                     </DropdownMenuContent>

--- a/src/components/team/team-member-report-view.tsx
+++ b/src/components/team/team-member-report-view.tsx
@@ -164,7 +164,7 @@ export function TeamMemberReportView({
         className="bg-white p-6 print:border-none print:shadow-none"
         data-testid="member-report-view-card"
       >
-        <p className="text-muted-foreground text-center">
+        <p className="text-center text-muted-foreground">
           {t('reports.notPublishedDetail')}
         </p>
       </div>
@@ -200,7 +200,7 @@ export function TeamMemberReportView({
                       data-testid="member-report-export-button"
                       disabled={entries.length === 0}
                     >
-                      <Download className="mr-2 h-4 w-4" />
+                      <Download className="mr-2 size-4" />
                       {t('export.exportButton')}
                     </Button>
                   </span>
@@ -223,7 +223,7 @@ export function TeamMemberReportView({
                       data-testid="member-report-pdf-button"
                       disabled={entries.length === 0}
                     >
-                      <Printer className="mr-2 h-4 w-4" />
+                      <Printer className="mr-2 size-4" />
                       {t('export.exportPdfButton')}
                     </Button>
                   </span>
@@ -240,7 +240,7 @@ export function TeamMemberReportView({
             </div>
           </div>
 
-          <div className="[&_.printable-area]:rounded-none [&_.printable-area]:shadow-none [&_.printable-area]:p-0">
+          <div className="[&_.printable-area]:rounded-none [&_.printable-area]:p-0 [&_.printable-area]:shadow-none">
             <TimesheetPreview
               selectedMonth={selectedMonth}
               user={mockUser}

--- a/src/components/team/team-members-list.tsx
+++ b/src/components/team/team-members-list.tsx
@@ -131,13 +131,13 @@ export function TeamMembersList({
   const getRoleIcon = (role: TeamMember['role']) => {
     switch (role) {
       case 'owner':
-        return <ShieldCheck className="h-4 w-4 text-blue-600" />
+        return <ShieldCheck className="size-4 text-blue-600" />
       case 'admin':
-        return <Shield className="h-4 w-4 text-green-600" />
+        return <Shield className="size-4 text-green-600" />
       case 'member':
-        return <User className="h-4 w-4 text-gray-600" />
+        return <User className="size-4 text-gray-600" />
       default:
-        return <User className="h-4 w-4 text-gray-600" />
+        return <User className="size-4 text-gray-600" />
     }
   }
 
@@ -173,7 +173,7 @@ export function TeamMembersList({
       {canManageSeats && (
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Users className="h-4 w-4" />
+            <Users className="size-4" />
             <span className="text-sm text-muted-foreground">
               {t('teams.seatsUsed', { used: assignedSeats, total: totalSeats })}
             </span>
@@ -183,7 +183,7 @@ export function TeamMembersList({
             size="sm"
             onClick={() => setShowSeatAssignmentDialog(true)}
           >
-            <Users className="mr-2 h-4 w-4" />
+            <Users className="mr-2 size-4" />
             {t('teams.seatAssignment')}
           </Button>
         </div>
@@ -237,11 +237,11 @@ export function TeamMembersList({
                       <DropdownMenuTrigger asChild>
                         <Button
                           variant="ghost"
-                          className="h-8 w-8 p-0"
+                          className="size-8 p-0"
                           disabled={loadingMemberId === member.id}
                           aria-label={t('teams.memberOptions')}
                         >
-                          <MoreHorizontal className="h-4 w-4" />
+                          <MoreHorizontal className="size-4" />
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
@@ -254,7 +254,7 @@ export function TeamMembersList({
                                     handleUpdateRole(member.id, 'admin')
                                   }
                                 >
-                                  <Shield className="mr-2 h-4 w-4" />
+                                  <Shield className="mr-2 size-4" />
                                   {t('teams.makeAdmin')}
                                 </DropdownMenuItem>
                               )}
@@ -264,7 +264,7 @@ export function TeamMembersList({
                                     handleUpdateRole(member.id, 'member')
                                   }
                                 >
-                                  <User className="mr-2 h-4 w-4" />
+                                  <User className="mr-2 size-4" />
                                   {t('teams.makeMember')}
                                 </DropdownMenuItem>
                               )}
@@ -275,7 +275,7 @@ export function TeamMembersList({
                           className="text-red-600"
                           onClick={() => handleRemoveMember(member.id)}
                         >
-                          <UserX className="mr-2 h-4 w-4" />
+                          <UserX className="mr-2 size-4" />
                           {t('teams.removeMember')}
                         </DropdownMenuItem>
                       </DropdownMenuContent>

--- a/src/components/team/team-options-card.tsx
+++ b/src/components/team/team-options-card.tsx
@@ -171,7 +171,7 @@ export function TeamOptionsCard({ teamId, canEdit }: TeamOptionsCardProps) {
               <div className="space-y-1">
                 <h3
                   id="team-options-compensation-heading"
-                  className="text-base font-semibold leading-none tracking-tight"
+                  className="text-base leading-none font-semibold tracking-tight"
                 >
                   {t('teams.compensationDefaults')}
                 </h3>
@@ -262,7 +262,7 @@ export function TeamOptionsCard({ teamId, canEdit }: TeamOptionsCardProps) {
               <div className="space-y-1">
                 <h3
                   id="team-options-export-heading"
-                  className="text-base font-semibold leading-none tracking-tight"
+                  className="text-base leading-none font-semibold tracking-tight"
                 >
                   {t('teams.exportDefaults')}
                 </h3>
@@ -355,9 +355,9 @@ export function TeamOptionsCard({ teamId, canEdit }: TeamOptionsCardProps) {
                   data-testid="saveTeamSettingsButton"
                 >
                   {isSaving ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    <Loader2 className="mr-2 size-4 animate-spin" />
                   ) : (
-                    <Save className="mr-2 h-4 w-4" />
+                    <Save className="mr-2 size-4" />
                   )}
                   {isSaving ? t('common.saving') : t('common.save')}
                 </Button>

--- a/src/components/team/team-reports-grid.tsx
+++ b/src/components/team/team-reports-grid.tsx
@@ -56,7 +56,7 @@ export function TeamReportsGrid({
               </div>
             ) : (
               <div className="space-y-3">
-                <h3 className="font-semibold text-lg">
+                <h3 className="text-lg font-semibold">
                   {displayNames.get(summary.member.id) ||
                     (summary.userSettings?.displayName ?? '').trim() ||
                     maskEmail(summary.member.email) ||
@@ -107,7 +107,7 @@ export function TeamReportsGrid({
                       </div>
                     </>
                   ) : (
-                    <p className="text-muted-foreground text-sm">
+                    <p className="text-sm text-muted-foreground">
                       {t('reports.notPublished')}
                     </p>
                   )}

--- a/src/components/team/team-reports-list.tsx
+++ b/src/components/team/team-reports-list.tsx
@@ -40,7 +40,7 @@ export function TeamReportsList({
 
   if (members.length === 0) {
     return (
-      <div className="text-center text-muted-foreground py-8">
+      <div className="py-8 text-center text-muted-foreground">
         {t('reports.noMembers')}
       </div>
     )
@@ -78,16 +78,16 @@ export function TeamReportsList({
                     <Skeleton className="h-4 w-48" />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Skeleton className="h-4 w-16 ml-auto" />
+                    <Skeleton className="ml-auto h-4 w-16" />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Skeleton className="h-4 w-16 ml-auto" />
+                    <Skeleton className="ml-auto h-4 w-16" />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Skeleton className="h-4 w-16 ml-auto" />
+                    <Skeleton className="ml-auto h-4 w-16" />
                   </TableCell>
                   <TableCell className="text-right">
-                    <Skeleton className="h-4 w-16 ml-auto" />
+                    <Skeleton className="ml-auto h-4 w-16" />
                   </TableCell>
                 </TableRow>
               ))

--- a/src/components/team/team-reports-tab.tsx
+++ b/src/components/team/team-reports-tab.tsx
@@ -63,7 +63,7 @@ export function TeamReportsTab({ teamId, members }: TeamReportsTabProps) {
                   className="h-8"
                   aria-label={t('reports.viewGrid')}
                 >
-                  <Grid3x3 className="h-4 w-4" />
+                  <Grid3x3 className="size-4" />
                 </Button>
                 <Button
                   variant={reportsViewMode === 'list' ? 'default' : 'ghost'}
@@ -72,7 +72,7 @@ export function TeamReportsTab({ teamId, members }: TeamReportsTabProps) {
                   className="h-8"
                   aria-label={t('reports.viewList')}
                 >
-                  <List className="h-4 w-4" />
+                  <List className="size-4" />
                 </Button>
               </div>
             </div>
@@ -94,7 +94,7 @@ export function TeamReportsTab({ teamId, members }: TeamReportsTabProps) {
               }
               data-testid="reports-previous-month-button"
             >
-              <ChevronLeft className="h-4 w-4" />
+              <ChevronLeft className="size-4" />
             </Button>
             <h3 className="text-lg font-semibold" data-testid="reports-month">
               {format.dateTime(reportsSelectedMonth, 'monthYear')}
@@ -113,7 +113,7 @@ export function TeamReportsTab({ teamId, members }: TeamReportsTabProps) {
               }
               data-testid="reports-next-month-button"
             >
-              <ChevronRight className="h-4 w-4" />
+              <ChevronRight className="size-4" />
             </Button>
           </div>
           {reportsViewMode === 'grid' ? (
@@ -151,7 +151,7 @@ export function TeamReportsTab({ teamId, members }: TeamReportsTabProps) {
             }
           }}
         >
-          <DialogContent className="max-w-[80vw] max-h-[80vh] w-full overflow-y-auto !border-0 !bg-white !p-0 !shadow-none [&>button]:hidden">
+          <DialogContent className="max-h-[80vh] w-full max-w-[80vw] overflow-y-auto border-0! bg-white! p-0! shadow-none! [&>button]:hidden">
             <DialogHeader className="hidden">
               <DialogTitle className="sr-only">
                 {selectedMemberId

--- a/src/components/team/team-settings-dialog.tsx
+++ b/src/components/team/team-settings-dialog.tsx
@@ -199,17 +199,17 @@ export function TeamSettingsDialog({
               <Input
                 value={team.id}
                 disabled
-                className="font-mono text-sm pr-10"
+                className="pr-10 font-mono text-sm"
               />
               <Button
                 type="button"
                 variant="link"
                 size="icon"
                 onClick={handleCopyTeamId}
-                className="absolute right-1 top-1/2 -translate-y-1/2 h-8 w-8"
+                className="absolute top-1/2 right-1 size-8 -translate-y-1/2"
                 title={t('teams.teamId')}
               >
-                <Copy className="h-4 w-4" />
+                <Copy className="size-4" />
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/src/components/team/team-subscription-card.tsx
+++ b/src/components/team/team-subscription-card.tsx
@@ -79,9 +79,9 @@ export function TeamSubscriptionCard({
     switch (status) {
       case 'active':
       case 'trialing':
-        return <Check className="h-4 w-4" />
+        return <Check className="size-4" />
       default:
-        return <AlertCircle className="h-4 w-4" />
+        return <AlertCircle className="size-4" />
     }
   }
 
@@ -147,7 +147,7 @@ export function TeamSubscriptionCard({
             <div className="flex items-center justify-between">
               <div>
                 <CardTitle className="flex items-center gap-2">
-                  <CreditCard className="h-5 w-5" />
+                  <CreditCard className="size-5" />
                   {t('teams.teamSubscription')}
                 </CardTitle>
                 <CardDescription>
@@ -161,18 +161,18 @@ export function TeamSubscriptionCard({
                 disabled={isRefreshing}
               >
                 <RefreshCw
-                  className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
+                  className={`size-4 ${isRefreshing ? 'animate-spin' : ''}`}
                 />
               </Button>
             </div>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="text-center py-6">
-              <CreditCard className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <h3 className="text-lg font-medium mb-2">
+            <div className="py-6 text-center">
+              <CreditCard className="mx-auto mb-4 size-12 text-muted-foreground" />
+              <h3 className="mb-2 text-lg font-medium">
                 {t('teams.noActiveSubscription')}
               </h3>
-              <p className="text-muted-foreground mb-6">
+              <p className="mb-6 text-muted-foreground">
                 {t('teams.noActiveSubscriptionDescription')}
               </p>
               <div className="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
@@ -188,7 +188,7 @@ export function TeamSubscriptionCard({
                 {(currentUserRole === 'owner' ||
                   currentUserRole === 'admin') && (
                   <Button onClick={handleUpgradeSubscription}>
-                    <Plus className="mr-2 h-4 w-4" />
+                    <Plus className="mr-2 size-4" />
                     {t('teams.subscribeNow')}
                   </Button>
                 )}
@@ -238,7 +238,7 @@ export function TeamSubscriptionCard({
           <div className="flex items-center justify-between">
             <div>
               <CardTitle className="flex items-center gap-2">
-                <CreditCard className="h-5 w-5" />
+                <CreditCard className="size-5" />
                 {t('teams.teamSubscription')}
               </CardTitle>
               <CardDescription>
@@ -252,7 +252,7 @@ export function TeamSubscriptionCard({
               disabled={isRefreshing}
             >
               <RefreshCw
-                className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
+                className={`size-4 ${isRefreshing ? 'animate-spin' : ''}`}
               />
             </Button>
           </div>
@@ -275,8 +275,8 @@ export function TeamSubscriptionCard({
           {/* Seat Usage */}
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <p className="font-medium flex items-center gap-2">
-                <Users className="h-4 w-4" />
+              <p className="flex items-center gap-2 font-medium">
+                <Users className="size-4" />
                 {t('teams.seatUsage')}
               </p>
               <div className="flex items-center gap-2">
@@ -290,7 +290,7 @@ export function TeamSubscriptionCard({
                       size="sm"
                       onClick={() => setShowSeatAssignmentDialog(true)}
                     >
-                      <Users className="mr-2 h-4 w-4" />
+                      <Users className="mr-2 size-4" />
                       {t('teams.seatAssignment')}
                     </Button>
                   )}
@@ -298,8 +298,8 @@ export function TeamSubscriptionCard({
             </div>
             <Progress value={seatUsagePercentage} className="h-2" />
             {usersWithoutSeats > 0 && (
-              <p className="text-sm text-amber-600 flex items-center gap-2">
-                <AlertTriangle className="h-4 w-4" />
+              <p className="flex items-center gap-2 text-sm text-amber-600">
+                <AlertTriangle className="size-4" />
                 {t('teams.usersWithoutSeats', { count: usersWithoutSeats })}
               </p>
             )}
@@ -340,7 +340,7 @@ export function TeamSubscriptionCard({
                   disabled={isLoading}
                   className="flex-1"
                 >
-                  <CreditCard className="mr-2 h-4 w-4" />
+                  <CreditCard className="mr-2 size-4" />
                   {isLoading
                     ? t('common.loading')
                     : t('subscription.manageBilling')}
@@ -348,7 +348,7 @@ export function TeamSubscriptionCard({
               </div>
               {usersWithoutSeats > 0 && (
                 <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm">
-                  <p className="font-medium text-amber-900 mb-1">
+                  <p className="mb-1 font-medium text-amber-900">
                     {t('teams.updateSeatsTitle')}
                   </p>
                   <p className="text-amber-800">

--- a/src/components/team/team-subscription-dialog.tsx
+++ b/src/components/team/team-subscription-dialog.tsx
@@ -172,7 +172,7 @@ export function TeamSubscriptionDialog({
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              <CreditCard className="h-5 w-5" />
+              <CreditCard className="size-5" />
               {t('teams.createTeamSubscription')}
             </DialogTitle>
             <DialogDescription>
@@ -181,7 +181,7 @@ export function TeamSubscriptionDialog({
           </DialogHeader>
           <div className="flex items-center justify-center py-8">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
+              <div className="mx-auto mb-4 size-8 animate-spin rounded-full border-b-2 border-primary"></div>
               <p className="text-muted-foreground">{t('common.loading')}</p>
             </div>
           </div>
@@ -195,7 +195,7 @@ export function TeamSubscriptionDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <CreditCard className="h-5 w-5" />
+            <CreditCard className="size-5" />
             {t('teams.createTeamSubscription')}
           </DialogTitle>
           <DialogDescription>
@@ -205,7 +205,7 @@ export function TeamSubscriptionDialog({
 
         <div className="space-y-6">
           {/* Billing Frequency Toggle */}
-          <div className="flex justify-center items-center space-x-4">
+          <div className="flex items-center justify-center space-x-4">
             <Label htmlFor="billing-toggle" className="text-sm font-medium">
               {t('landing.pricing.monthly')}
             </Label>
@@ -243,7 +243,7 @@ export function TeamSubscriptionDialog({
                   return (
                     <div
                       key={plan.id}
-                      className={`relative border rounded-lg p-4 cursor-pointer transition-colors ${
+                      className={`relative cursor-pointer rounded-lg border p-4 transition-colors ${
                         selectedPlan?.id === plan.id
                           ? 'border-primary bg-primary/5'
                           : 'border-border hover:border-primary/50'
@@ -256,13 +256,13 @@ export function TeamSubscriptionDialog({
                       />
                       <div className="flex items-start justify-between">
                         <div className="flex-1">
-                          <div className="flex items-center gap-2 mb-2">
+                          <div className="mb-2 flex items-center gap-2">
                             <h3 className="font-medium">{plan.name}</h3>
                             {selectedPlan?.id === plan.id && (
-                              <Check className="h-4 w-4 text-primary" />
+                              <Check className="size-4 text-primary" />
                             )}
                           </div>
-                          <p className="text-sm text-muted-foreground mb-3">
+                          <p className="mb-3 text-sm text-muted-foreground">
                             {plan.features.slice(0, 3).join(' • ')}
                           </p>
                           <div className="text-sm">
@@ -303,7 +303,7 @@ export function TeamSubscriptionDialog({
               </RadioGroup>
             </div>
           ) : (
-            <div className="text-center py-6">
+            <div className="py-6 text-center">
               <p className="text-muted-foreground">
                 {t('teams.noTeamPlansAvailable')}
               </p>
@@ -314,7 +314,7 @@ export function TeamSubscriptionDialog({
           {selectedPlan && (
             <div className="space-y-4">
               <Label htmlFor="seats" className="flex items-center gap-2">
-                <Users className="h-4 w-4" />
+                <Users className="size-4" />
                 {t('teams.numberOfSeats')}
               </Label>
 
@@ -327,7 +327,7 @@ export function TeamSubscriptionDialog({
                   disabled={seats <= Math.max(currentMembersCount, 1)}
                   aria-label="Decrease seats"
                 >
-                  <Minus className="h-4 w-4" />
+                  <Minus className="size-4" />
                 </Button>
 
                 <Input
@@ -350,7 +350,7 @@ export function TeamSubscriptionDialog({
                   disabled={seats >= (selectedPlan.maxUsers || 50)}
                   aria-label="Increase seats"
                 >
-                  <Plus className="h-4 w-4" />
+                  <Plus className="size-4" />
                 </Button>
               </div>
 
@@ -370,7 +370,7 @@ export function TeamSubscriptionDialog({
           {/* Final Pricing Summary */}
           {selectedPlan && (
             <div className="border-t pt-4">
-              <div className="flex items-center justify-between mb-2">
+              <div className="mb-2 flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
                   {t('teams.seatsSelected', { count: seats })}
                 </span>
@@ -418,7 +418,7 @@ export function TeamSubscriptionDialog({
             onClick={handleSubscribe}
             disabled={isLoading || !selectedPlan}
           >
-            <CreditCard className="mr-2 h-4 w-4" />
+            <CreditCard className="mr-2 size-4" />
             {isLoading ? t('common.loading') : t('teams.subscribeNow')}
           </Button>
         </DialogFooter>

--- a/src/components/team/user-invitations-list.tsx
+++ b/src/components/team/user-invitations-list.tsx
@@ -123,7 +123,7 @@ export function UserInvitationsList({
 
   if (invitations.length === 0) {
     return (
-      <div className="text-center py-6 text-muted-foreground">
+      <div className="py-6 text-center text-muted-foreground">
         {t('teams.noPendingInvitations')}
       </div>
     )
@@ -138,7 +138,7 @@ export function UserInvitationsList({
             <TableHead>{t('teams.role')}</TableHead>
             <TableHead>{t('teams.status')}</TableHead>
             <TableHead>{t('teams.expires')}</TableHead>
-            <TableHead className="w-[120px]">{t('teams.actions')}</TableHead>
+            <TableHead className="w-30">{t('teams.actions')}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -149,7 +149,7 @@ export function UserInvitationsList({
               <TableRow key={invitation.id}>
                 <TableCell>
                   <div className="flex items-center gap-2">
-                    <Mail className="h-4 w-4 text-muted-foreground" />
+                    <Mail className="size-4 text-muted-foreground" />
                     <span className="font-medium">
                       {t('teams.teamInvitation')}
                     </span>
@@ -158,7 +158,7 @@ export function UserInvitationsList({
                 <TableCell>{getRoleLabel(invitation.role)}</TableCell>
                 <TableCell>
                   <div className="flex items-center gap-2">
-                    <Clock className="h-4 w-4 text-amber-500" />
+                    <Clock className="size-4 text-amber-500" />
                     <span
                       className={expired ? 'text-red-600' : 'text-amber-600'}
                     >
@@ -178,7 +178,7 @@ export function UserInvitationsList({
                         disabled={loadingInvitationId === invitation.id}
                         className="h-8"
                       >
-                        <Check className="mr-1 h-3 w-3" />
+                        <Check className="mr-1 size-3" />
                         {t('teams.accept')}
                       </Button>
                       <Button
@@ -188,7 +188,7 @@ export function UserInvitationsList({
                         disabled={loadingInvitationId === invitation.id}
                         className="h-8"
                       >
-                        <X className="mr-1 h-3 w-3" />
+                        <X className="mr-1 size-3" />
                         {t('teams.decline')}
                       </Button>
                     </div>

--- a/src/components/time-entries-list.tsx
+++ b/src/components/time-entries-list.tsx
@@ -121,7 +121,7 @@ const TimeEntriesList: React.FC = () => {
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="flex shrink">{listTitle}</CardTitle>
-          <div className="text-nowrap text-lg font-bold text-primary">
+          <div className="text-lg font-bold text-nowrap text-primary">
             {formatHoursAndMinutes(dailyTotal)}
           </div>
         </div>
@@ -134,7 +134,7 @@ const TimeEntriesList: React.FC = () => {
                 onClick={handleCopyFromYesterday}
                 data-testid="copy-from-yesterday-button"
               >
-                <Copy className="mr-2 h-4 w-4" />
+                <Copy className="mr-2 size-4" />
                 {t('tracker.copyFromYesterday')}
               </SubscriptionGuardButton>
             )}
@@ -153,7 +153,7 @@ const TimeEntriesList: React.FC = () => {
                   size="sm"
                   data-testid="copy-day-to-button"
                 >
-                  <Copy className="mr-2 h-4 w-4" />
+                  <Copy className="mr-2 size-4" />
                   {t('tracker.copyDayTo')}
                 </SubscriptionGuardButton>
               </CopyToDatePicker>

--- a/src/components/time-entry-card.tsx
+++ b/src/components/time-entry-card.tsx
@@ -97,19 +97,19 @@ export default function TimeEntryCard({
         <CardContent className="p-4">
           <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-3">
-              <SpecialIcon className="h-5 w-5 text-primary" />
+              <SpecialIcon className="size-5 text-primary" />
               <p className="font-semibold">
                 {getLocationDisplayName(entry.location, t)}
               </p>
             </div>
             <div className="flex items-center gap-2">
-              <p className="font-mono text-lg font-medium tabular-nums text-primary">
+              <p className="font-mono text-lg font-medium text-primary tabular-nums">
                 {totalCompensatedSeconds > 0
                   ? formatDuration(totalCompensatedSeconds)
                   : '—'}
               </p>
               <Button variant="ghost" size="icon" onClick={() => onEdit(entry)}>
-                <Edit className="h-4 w-4" />
+                <Edit className="size-4" />
                 <span className="sr-only">
                   {t('time_entry_card.editLabel')}
                 </span>
@@ -130,7 +130,7 @@ export default function TimeEntryCard({
                   title={t('time_entry_card.copyToTitle')}
                 >
                   <Button variant="ghost" size="icon">
-                    <Copy className="h-4 w-4" />
+                    <Copy className="size-4" />
                     <span className="sr-only">
                       {t('time_entry_card.copyToLabel')}
                     </span>
@@ -144,7 +144,7 @@ export default function TimeEntryCard({
                     size="icon"
                     className="text-destructive hover:text-destructive"
                   >
-                    <Trash2 className="h-4 w-4" />
+                    <Trash2 className="size-4" />
                     <span className="sr-only">
                       {t('time_entry_card.deleteLabel')}
                     </span>
@@ -191,7 +191,7 @@ export default function TimeEntryCard({
             <p className="font-semibold">{entry.location}</p>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-muted-foreground">
               <div className="flex items-center">
-                <Clock className="mr-1.5 h-3.5 w-3.5" />
+                <Clock className="mr-1.5 size-3.5" />
                 {typeof entry.durationMinutes === 'number' ? (
                   <span>
                     {t('time_entry_form.durationLabel')}:{' '}
@@ -205,7 +205,7 @@ export default function TimeEntryCard({
               </div>
               {entry.pauseDuration !== undefined && entry.pauseDuration > 0 && (
                 <div className="flex items-center">
-                  <Coffee className="mr-1.5 h-3.5 w-3.5" />
+                  <Coffee className="mr-1.5 size-3.5" />
                   <span>
                     {t('time_entry_card.pauseLabel', {
                       minutes: entry.pauseDuration,
@@ -216,7 +216,7 @@ export default function TimeEntryCard({
               {entry.driverTimeHours !== undefined &&
                 entry.driverTimeHours > 0 && (
                   <div className="flex items-center">
-                    <CarFront className="mr-1.5 h-3.5 w-3.5" />
+                    <CarFront className="mr-1.5 size-3.5" />
                     <span>
                       {t('time_entry_card.drivingLabel', {
                         hours: entry.driverTimeHours,
@@ -227,7 +227,7 @@ export default function TimeEntryCard({
               {entry.passengerTimeHours !== undefined &&
                 entry.passengerTimeHours > 0 && (
                   <div className="flex items-center">
-                    <UserPlus className="mr-1.5 h-3.5 w-3.5" />
+                    <UserPlus className="mr-1.5 size-3.5" />
                     <span>
                       {t('time_entry_card.passengerLabel', {
                         hours: entry.passengerTimeHours,
@@ -239,7 +239,7 @@ export default function TimeEntryCard({
                 Number.isFinite(entry.privateCarKilometers) &&
                 entry.privateCarKilometers > 0 && (
                   <div className="flex items-center">
-                    <Navigation className="mr-1.5 h-3.5 w-3.5" />
+                    <Navigation className="mr-1.5 size-3.5" />
                     <span>
                       {t('time_entry_card.privateCarKmLabel', {
                         km: entry.privateCarKilometers,
@@ -250,13 +250,13 @@ export default function TimeEntryCard({
             </div>
           </div>
           <div className="flex items-center gap-2">
-            <p className="font-mono text-lg font-medium tabular-nums text-primary">
+            <p className="font-mono text-lg font-medium text-primary tabular-nums">
               {totalCompensatedSeconds > 0
                 ? formatDuration(totalCompensatedSeconds)
                 : '—'}
             </p>
             <Button variant="ghost" size="icon" onClick={() => onEdit(entry)}>
-              <Edit className="h-4 w-4" />
+              <Edit className="size-4" />
               <span className="sr-only">{t('time_entry_card.editLabel')}</span>
             </Button>
             {onCopyTo && (
@@ -275,7 +275,7 @@ export default function TimeEntryCard({
                 title={t('time_entry_card.copyToTitle')}
               >
                 <Button variant="ghost" size="icon">
-                  <Copy className="h-4 w-4" />
+                  <Copy className="size-4" />
                   <span className="sr-only">
                     {t('time_entry_card.copyToLabel')}
                   </span>
@@ -289,7 +289,7 @@ export default function TimeEntryCard({
                   size="icon"
                   className="text-destructive hover:text-destructive"
                 >
-                  <Trash2 className="h-4 w-4" />
+                  <Trash2 className="size-4" />
                   <span className="sr-only">
                     {t('time_entry_card.deleteLabel')}
                   </span>

--- a/src/components/time-entry-form.tsx
+++ b/src/components/time-entry-form.tsx
@@ -559,7 +559,7 @@ export default function TimeEntryForm({
                               !field.value && 'text-muted-foreground',
                             )}
                           >
-                            <CalendarIcon className="mr-2 h-4 w-4" />
+                            <CalendarIcon className="mr-2 size-4" />
                             {field.value ? (
                               format(field.value, 'long')
                             ) : (
@@ -584,7 +584,7 @@ export default function TimeEntryForm({
                 control={form.control}
                 name="mode"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-center gap-4 mb-2">
+                  <FormItem className="mb-2 flex flex-row items-center gap-4">
                     <FormLabel className="mr-2">
                       {t('time_entry_form.modeInterval')}
                     </FormLabel>
@@ -619,7 +619,7 @@ export default function TimeEntryForm({
                         {/* Start time suggestions */}
                         {startTimeSuggestions.length > 0 && (
                           <div
-                            className="flex gap-2 mt-2"
+                            className="mt-2 flex gap-2"
                             data-testid="start-time-suggestions"
                           >
                             {startTimeSuggestions.map((s) => (
@@ -629,14 +629,14 @@ export default function TimeEntryForm({
                                     type="button"
                                     variant="ghost"
                                     size="sm"
-                                    className="h-auto p-1 text-primary hover:bg-primary/10 flex items-center gap-1"
+                                    className="flex h-auto items-center gap-1 p-1 text-primary hover:bg-primary/10"
                                     onClick={() =>
                                       setValue('startTime', s, {
                                         shouldValidate: true,
                                       })
                                     }
                                   >
-                                    <Lightbulb className="h-4 w-4 mr-1 opacity-70" />
+                                    <Lightbulb className="mr-1 size-4 opacity-70" />
                                     {s}
                                   </Button>
                                 </TooltipTrigger>
@@ -664,7 +664,7 @@ export default function TimeEntryForm({
                         </FormControl>
                         {/* End time suggestions */}
                         {endTimeSuggestions.length > 0 && (
-                          <div className="flex gap-2 mt-2">
+                          <div className="mt-2 flex gap-2">
                             {endTimeSuggestions.map((s) => (
                               <Tooltip key={s}>
                                 <TooltipTrigger asChild>
@@ -672,14 +672,14 @@ export default function TimeEntryForm({
                                     type="button"
                                     variant="ghost"
                                     size="sm"
-                                    className="h-auto p-1 text-primary hover:bg-primary/10 flex items-center gap-1"
+                                    className="flex h-auto items-center gap-1 p-1 text-primary hover:bg-primary/10"
                                     onClick={() =>
                                       setValue('endTime', s, {
                                         shouldValidate: true,
                                       })
                                     }
                                   >
-                                    <Lightbulb className="h-4 w-4 mr-1 opacity-70" />
+                                    <Lightbulb className="mr-1 size-4 opacity-70" />
                                     {s}
                                   </Button>
                                 </TooltipTrigger>
@@ -742,7 +742,7 @@ export default function TimeEntryForm({
                             />
                           </FormControl>
                           {field.value && !isValidDuration(field.value) && (
-                            <div className="text-sm font-medium text-destructive mt-1">
+                            <div className="mt-1 text-sm font-medium text-destructive">
                               {t('time_entry_form.pauseDurationInvalid', {
                                 example: '00:30',
                               })}
@@ -771,7 +771,7 @@ export default function TimeEntryForm({
                                       )
                                     }
                                   >
-                                    <Lightbulb className="mr-1 h-4 w-4" />
+                                    <Lightbulb className="mr-1 size-4" />
                                     {t('time_entry_form.pauseSuggestion', {
                                       minutes: pauseSuggestion.minutes,
                                     })}
@@ -811,7 +811,7 @@ export default function TimeEntryForm({
                               />
                             </FormControl>
                             {driverTimeSuggestions.length > 0 && (
-                              <div className="flex gap-2 mt-2">
+                              <div className="mt-2 flex gap-2">
                                 {driverTimeSuggestions.map((s) => (
                                   <Tooltip key={s}>
                                     <TooltipTrigger asChild>
@@ -819,7 +819,7 @@ export default function TimeEntryForm({
                                         type="button"
                                         variant="ghost"
                                         size="sm"
-                                        className="h-auto p-1 text-primary hover:bg-primary/10 flex items-center gap-1"
+                                        className="flex h-auto items-center gap-1 p-1 text-primary hover:bg-primary/10"
                                         onClick={() =>
                                           setValue(
                                             'driverTimeHours',
@@ -830,7 +830,7 @@ export default function TimeEntryForm({
                                           )
                                         }
                                       >
-                                        <Lightbulb className="h-4 w-4 mr-1 opacity-70" />
+                                        <Lightbulb className="mr-1 size-4 opacity-70" />
                                         {formatMinutesToTimeInput(s * 60)}
                                       </Button>
                                     </TooltipTrigger>
@@ -863,7 +863,7 @@ export default function TimeEntryForm({
                               />
                             </FormControl>
                             {passengerTimeSuggestions.length > 0 && (
-                              <div className="flex gap-2 mt-2">
+                              <div className="mt-2 flex gap-2">
                                 {passengerTimeSuggestions.map((s) => (
                                   <Tooltip key={s}>
                                     <TooltipTrigger asChild>
@@ -871,7 +871,7 @@ export default function TimeEntryForm({
                                         type="button"
                                         variant="ghost"
                                         size="sm"
-                                        className="h-auto p-1 text-primary hover:bg-primary/10 flex items-center gap-1"
+                                        className="flex h-auto items-center gap-1 p-1 text-primary hover:bg-primary/10"
                                         onClick={() =>
                                           setValue(
                                             'passengerTimeHours',
@@ -882,7 +882,7 @@ export default function TimeEntryForm({
                                           )
                                         }
                                       >
-                                        <Lightbulb className="h-4 w-4 mr-1 opacity-70" />
+                                        <Lightbulb className="mr-1 size-4 opacity-70" />
                                         {formatMinutesToTimeInput(s * 60)}
                                       </Button>
                                     </TooltipTrigger>
@@ -984,7 +984,7 @@ export default function TimeEntryForm({
               <div className="space-y-4 pt-4">
                 <Separator />
                 <div className="flex items-center justify-between font-medium">
-                  <span className="text-muted-foreground flex items-center gap-2">
+                  <span className="flex items-center gap-2 text-muted-foreground">
                     {t('time_entry_form.totalTimeLabel')}
                     <TooltipProvider>
                       <Tooltip>
@@ -997,7 +997,7 @@ export default function TimeEntryForm({
                             )}
                             className="ml-1 text-primary hover:text-primary/80 focus:outline-none"
                           >
-                            <Info className="w-4 h-4" />
+                            <Info className="size-4" />
                           </button>
                         </TooltipTrigger>
                         <TooltipContent
@@ -1016,7 +1016,7 @@ export default function TimeEntryForm({
                 </div>
                 {workDurationInMinutes > 10 * 60 && !isSpecialEntry && (
                   <Alert variant="destructive">
-                    <AlertTriangle className="h-4 w-4" />
+                    <AlertTriangle className="size-4" />
                     <AlertTitle>
                       {t('time_entry_form.warning10HoursTitle')}
                     </AlertTitle>
@@ -1073,7 +1073,7 @@ export default function TimeEntryForm({
                   </AlertDialogContent>
                 </AlertDialog>
                 <Button type="submit">
-                  <Save className="mr-2 h-4 w-4" />
+                  <Save className="mr-2 size-4" />
                   {t('time_entry_form.saveButton')}
                 </Button>
               </SheetFooter>

--- a/src/components/time-tracker-live-card.tsx
+++ b/src/components/time-tracker-live-card.tsx
@@ -53,7 +53,7 @@ const TimeTrackerLiveCard: React.FC = () => {
                   })}
                 </p>
               </div>
-              <p className="font-mono text-2xl font-bold tabular-nums tracking-wider text-primary">
+              <p className="font-mono text-2xl font-bold tracking-wider text-primary tabular-nums">
                 {formatDuration(elapsedTime)}
               </p>
             </div>
@@ -62,7 +62,7 @@ const TimeTrackerLiveCard: React.FC = () => {
                 onClick={handleStopTimer}
                 className="w-full bg-destructive transition-all duration-300 hover:bg-destructive/90"
               >
-                <Pause className="mr-2 h-4 w-4" />
+                <Pause className="mr-2 size-4" />
                 {t('tracker.stopButton')}
               </Button>
             </div>
@@ -86,9 +86,9 @@ const TimeTrackerLiveCard: React.FC = () => {
                     disabled={isFetchingLocation}
                   >
                     {isFetchingLocation ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Loader2 className="size-4 animate-spin" />
                     ) : (
-                      <MapPin className="h-4 w-4" />
+                      <MapPin className="size-4" />
                     )}
                   </Button>
                 </TooltipTrigger>
@@ -102,7 +102,7 @@ const TimeTrackerLiveCard: React.FC = () => {
               size="lg"
               className="w-full transition-all duration-300"
             >
-              <Play className="mr-2 h-4 w-4" />
+              <Play className="mr-2 size-4" />
               {t('tracker.startButton')}
             </Button>
           </div>

--- a/src/components/time-tracker.tsx
+++ b/src/components/time-tracker.tsx
@@ -27,8 +27,8 @@ export default function TimeTracker() {
 function TimeTrackerContent() {
   return (
     <div className="flex min-h-screen w-full flex-col">
-      <main className="p-2 sm:p-4 md:p-6 lg:p-8 pb-20 md:pb-8">
-        <div className="mx-auto flex flex-col w-full max-w-full sm:max-w-6xl gap-8">
+      <main className="p-2 pb-20 sm:p-4 md:p-6 md:pb-8 lg:p-8">
+        <div className="mx-auto flex w-full max-w-full flex-col gap-8 sm:max-w-6xl">
           <TimeTrackerLiveCard />
           <DailyActionsCard />
           <DateNavigation />

--- a/src/components/timesheet-header.tsx
+++ b/src/components/timesheet-header.tsx
@@ -36,7 +36,7 @@ const TimesheetHeader = ({ userSettings }: TimesheetHeaderProps) => {
 
   return (
     <div
-      className="mb-8 flex w-full flex-col justify-between text-sm print:mb-2 print:text-xs sm:flex-row"
+      className="mb-8 flex w-full flex-col justify-between text-sm sm:flex-row print:mb-2 print:text-xs"
       data-testid="timesheet-header"
     >
       <span>{t('export.headerCompany')}</span>

--- a/src/components/timesheet-preview-totals.tsx
+++ b/src/components/timesheet-preview-totals.tsx
@@ -193,7 +193,7 @@ export default function TimesheetPreviewTotals({
       <>
         {/* Right column - single label with 4 values */}
         <div
-          className={`col-span-full sm:col-span-6 print:col-span-6 flex gap-8 justify-between ${getOrderClasses(index, 'right')}`}
+          className={`col-span-full flex justify-between gap-8 sm:col-span-6 print:col-span-6 ${getOrderClasses(index, 'right')}`}
         >
           <div className="flex-1 text-right font-semibold">
             {row.rightColumn.label}
@@ -215,14 +215,14 @@ export default function TimesheetPreviewTotals({
 
         {/* Spacer for desktop */}
         <div
-          className={`hidden sm:block print:block sm:col-span-3 print:col-span-3 ${getOrderClasses(index, 'spacer')}`}
+          className={`hidden sm:col-span-3 sm:block print:col-span-3 print:block ${getOrderClasses(index, 'spacer')}`}
         />
 
         {/* Left column */}
         <div
-          className={`col-span-full sm:col-span-3 print:col-span-3 flex gap-8 justify-between ${getOrderClasses(index, 'left')}`}
+          className={`col-span-full flex justify-between gap-8 sm:col-span-3 print:col-span-3 ${getOrderClasses(index, 'left')}`}
         >
-          <div className="text-right flex-1 font-semibold">
+          <div className="flex-1 text-right font-semibold">
             {row.leftColumn.label}
           </div>
           <div
@@ -239,7 +239,7 @@ export default function TimesheetPreviewTotals({
   return (
     <div
       className={
-        'grid grid-cols-none sm:grid-cols-12 print:grid-cols-12 w-full gap-2 mt-8'
+        'mt-8 grid w-full grid-cols-none gap-2 sm:grid-cols-12 print:grid-cols-12'
       }
     >
       {rowsData.map((row, index) => (

--- a/src/components/timesheet-preview.tsx
+++ b/src/components/timesheet-preview.tsx
@@ -170,7 +170,7 @@ export default function TimesheetPreview({
                     </TableHead>
                     <TableHead
                       rowSpan={2}
-                      className="w-[8%] border-l border-r border-black align-middle print:h-auto print:p-1"
+                      className="w-[8%] border-x border-black align-middle print:h-auto print:p-1"
                     >
                       {t('export.headerPauseDuration')}
                     </TableHead>
@@ -247,10 +247,10 @@ export default function TimesheetPreview({
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                className="absolute right-0.5 top-1/2 h-7 w-7 -translate-y-1/2 opacity-0 focus-visible:opacity-100 group-hover:opacity-100 print:hidden"
+                                className="absolute top-1/2 right-0.5 size-7 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 print:hidden"
                                 onClick={() => onAdd(day)}
                               >
-                                <Plus className="h-4 w-4" />
+                                <Plus className="size-4" />
                                 <span className="sr-only">Add entry</span>
                               </Button>
                             )}
@@ -258,7 +258,7 @@ export default function TimesheetPreview({
                           <TableCell className="border-r border-black text-left text-muted-foreground print:p-1"></TableCell>
                           <TableCell className="text-right print:p-1"></TableCell>
                           <TableCell className="text-right print:p-1"></TableCell>
-                          <TableCell className="border-l border-r border-black text-right print:p-1"></TableCell>
+                          <TableCell className="border-x border-black text-right print:p-1"></TableCell>
                           {showDriverTimeCol && (
                             <TableCell className="border-r border-black text-right print:p-1"></TableCell>
                           )}
@@ -348,13 +348,13 @@ export default function TimesheetPreview({
                                 <Button
                                   variant="ghost"
                                   size="icon"
-                                  className="absolute right-0.5 top-1/2 h-7 w-7 -translate-y-1/2 opacity-0 focus-visible:opacity-100 group-hover:opacity-100 print:hidden"
+                                  className="absolute top-1/2 right-0.5 size-7 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 print:hidden"
                                   onClick={(e) => {
                                     e.stopPropagation()
                                     onAdd(day)
                                   }}
                                 >
-                                  <Plus className="h-4 w-4" />
+                                  <Plus className="size-4" />
                                   <span className="sr-only">Add entry</span>
                                 </Button>
                               )}
@@ -375,7 +375,7 @@ export default function TimesheetPreview({
                               ? ''
                               : toValue}
                           </TableCell>
-                          <TableCell className="border-l border-r border-black text-right print:p-1">
+                          <TableCell className="border-x border-black text-right print:p-1">
                             {/* Show blank if pause is 0 or 0.00 */}
                             {entry.pauseDuration && entry.pauseDuration !== 0
                               ? formatDecimalHours(entry.pauseDuration)
@@ -428,7 +428,7 @@ export default function TimesheetPreview({
               <div className="mt-2 flex w-full justify-end print:mt-1 print:text-xs">
                 <div className="flex w-full justify-end">
                   <div className="flex-1"></div>
-                  <div className="flex flex-1 gap-8 sm:w-1/2 justify-between">
+                  <div className="flex flex-1 justify-between gap-8 sm:w-1/2">
                     <div className="flex-1 text-right font-semibold">
                       {t('export.footerTotalPerWeek')}
                     </div>

--- a/src/components/trial-banner.tsx
+++ b/src/components/trial-banner.tsx
@@ -54,7 +54,7 @@ export default function TrialBanner({
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <Clock
-              className="h-5 w-5 text-blue-600"
+              className="size-5 text-blue-600"
               data-testid="trial-banner-clock-icon"
             />
             <div>
@@ -86,7 +86,7 @@ export default function TrialBanner({
             </Badge>
             {isTrialExpiringSoon && (
               <AlertTriangle
-                className="h-4 w-4 text-orange-500"
+                className="size-4 text-orange-500"
                 data-testid="trial-banner-warning-icon"
               />
             )}

--- a/src/components/try-for-free-button.tsx
+++ b/src/components/try-for-free-button.tsx
@@ -98,7 +98,7 @@ export default function TryForFreeButton({
       onClick={handleTryForFree}
       disabled={loading}
     >
-      {showIcon && <Sparkles className="h-4 w-4" />}
+      {showIcon && <Sparkles className="size-4" />}
       {loading ? t('pricing.processing') : t('pricing.tryForFree')}
     </Button>
   )

--- a/src/components/ui/__tests__/colorful-background.test.tsx
+++ b/src/components/ui/__tests__/colorful-background.test.tsx
@@ -16,13 +16,13 @@ describe('ColorfulBackground', () => {
 
   it('applies custom className', () => {
     render(
-      <ColorfulBackground className="custom-class">
+      <ColorfulBackground className="bg-amber-50">
         <div>Test Content</div>
       </ColorfulBackground>,
     )
 
     const container = screen.getByText('Test Content').parentElement
-    expect(container).toHaveClass('custom-class')
+    expect(container).toHaveClass('bg-amber-50')
     expect(container).toHaveClass('relative')
     expect(container).toHaveClass('isolate')
   })

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -36,7 +36,7 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+      <ChevronDown className="size-4 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ))
@@ -51,7 +51,7 @@ const AccordionContent = React.forwardRef<
     className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
-    <div className={cn('pb-4 pt-0', className)}>{children}</div>
+    <div className={cn('pt-0 pb-4', className)}>{children}</div>
   </AccordionPrimitive.Content>
 ))
 

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -19,7 +19,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -37,7 +37,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -5,7 +5,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  'relative w-full rounded-lg border p-4 [&>svg]:absolute [&>svg]:top-4 [&>svg]:left-4 [&>svg]:text-foreground [&>svg+div]:translate-y-[-3px] [&>svg~*]:pl-7',
   {
     variants: {
       variant: {
@@ -41,7 +41,7 @@ const AlertTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h5
     ref={ref}
-    className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+    className={cn('mb-1 leading-none font-medium tracking-tight', className)}
     {...props}
   >
     <span className="sr-only">Alert:</span>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -13,7 +13,7 @@ const Avatar = React.forwardRef<
   <AvatarPrimitive.Root
     ref={ref}
     className={cn(
-      'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full',
+      'relative flex size-10 shrink-0 overflow-hidden rounded-full',
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn('aspect-square h-full w-full', className)}
+    className={cn('aspect-square size-full', className)}
     {...props}
   />
 ))
@@ -40,7 +40,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      'flex h-full w-full items-center justify-center rounded-full bg-muted',
+      'flex size-full items-center justify-center rounded-full bg-muted',
       className,
     )}
     {...props}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none',
+  'badge inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none',
   {
     variants: {
       variant: {

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const badgeVariants = cva(
-  'badge inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none',
   {
     variants: {
       variant: {

--- a/src/components/ui/bottom-nav.tsx
+++ b/src/components/ui/bottom-nav.tsx
@@ -45,11 +45,11 @@ function NavLink({
   return (
     <Link
       href={href}
-      className="flex w-auto flex-col items-center justify-center h-12"
+      className="flex h-12 w-auto flex-col items-center justify-center"
       {...(isActive ? { 'aria-current': 'page' } : {})}
     >
       <Icon
-        className={`mb-1 h-6 w-6 ${isActive ? 'text-primary' : 'text-gray-400'}`}
+        className={`mb-1 size-6 ${isActive ? 'text-primary' : 'text-gray-400'}`}
       />
       <span
         className={`block text-xs ${isActive ? 'font-semibold text-primary' : 'text-gray-500'}`}
@@ -81,7 +81,7 @@ export default function BottomNav() {
             const isActive = pathname === href
             const label = t(labelKey, { defaultValue: labelDefault })
             return (
-              <li key={href} className="flex-1 flex justify-center">
+              <li key={href} className="flex flex-1 justify-center">
                 {requiresSubscription ? (
                   <SubscriptionGuardButton
                     className="rounded-none p-0"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -26,7 +26,7 @@ const buttonVariants = cva(
         default: 'h-10 px-4 py-2',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        icon: 'size-10',
       },
     },
     defaultVariants: {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -32,9 +32,9 @@ function Calendar({
           [_: string]: unknown
         }) =>
           props.orientation === 'left' ? (
-            <ChevronLeft className={cn('h-4 w-4', className)} {...props} />
+            <ChevronLeft className={cn('size-4', className)} {...props} />
           ) : (
-            <ChevronRight className={cn('h-4 w-4', className)} {...props} />
+            <ChevronRight className={cn('size-4', className)} {...props} />
           ),
       }}
       {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h1
     ref={ref}
     className={cn(
-      'font-headline text-2xl font-semibold leading-none tracking-tight',
+      'font-headline text-2xl leading-none font-semibold tracking-tight',
       className,
     )}
     {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -15,7 +15,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer size-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
       className,
     )}
     {...props}
@@ -23,7 +23,7 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn('flex items-center justify-center text-current')}
     >
-      <Check className="h-4 w-4" />
+      <Check className="size-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/src/components/ui/colorful-background.tsx
+++ b/src/components/ui/colorful-background.tsx
@@ -25,7 +25,7 @@ export default function ColorfulBackground({
     <div className={`relative isolate ${className}`}>
       {/* Top gradient */}
       <div
-        className="absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80 pointer-events-none"
+        className="pointer-events-none absolute inset-x-0 -top-40 -z-10 transform-gpu overflow-hidden blur-3xl sm:-top-80"
         aria-hidden="true"
       >
         <div
@@ -39,7 +39,7 @@ export default function ColorfulBackground({
 
       {/* Bottom gradient */}
       <div
-        className="absolute inset-x-0 -bottom-16 -z-10 transform-gpu overflow-hidden blur-3xl pointer-events-none"
+        className="pointer-events-none absolute inset-x-0 -bottom-16 -z-10 transform-gpu overflow-hidden blur-3xl"
         aria-hidden="true"
       >
         <div

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -23,7 +23,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -40,14 +40,14 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-[-50%] gap-4 border bg-white p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+      <DialogPrimitive.Close className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="size-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
@@ -90,7 +90,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      'text-lg font-semibold leading-none tracking-tight',
+      'text-lg leading-none font-semibold tracking-tight',
       className,
     )}
     {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -29,7 +29,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none select-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -49,7 +49,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
       className,
     )}
     {...props}
@@ -67,7 +67,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         className,
       )}
       {...props}
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm transition-colors outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       inset && 'pl-8',
       className,
     )}
@@ -101,15 +101,15 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm transition-colors outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-4" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -125,14 +125,14 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm transition-colors outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="size-2 fill-current" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/src/components/ui/duration-picker.tsx
+++ b/src/components/ui/duration-picker.tsx
@@ -63,7 +63,7 @@ function Wheel({ items, selected, onSelect, testId }: WheelProps) {
       ref={containerRef}
       data-testid={testId}
       style={{ scrollbarWidth: 'thin' }}
-      className="h-48 w-16 overflow-y-auto snap-y snap-mandatory rounded-md border [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30 [&::-webkit-scrollbar-track]:bg-transparent"
+      className="h-48 w-16 snap-y snap-mandatory overflow-y-auto rounded-md border [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-muted-foreground/30 [&::-webkit-scrollbar-track]:bg-transparent"
     >
       {items.map((item) => (
         <button
@@ -72,9 +72,9 @@ function Wheel({ items, selected, onSelect, testId }: WheelProps) {
           data-value={item}
           onClick={() => onSelect(item)}
           className={cn(
-            'h-10 w-full snap-start flex items-center justify-center text-sm',
+            'flex h-10 w-full snap-start items-center justify-center text-sm',
             selected === item
-              ? 'bg-primary text-primary-foreground font-medium'
+              ? 'bg-primary font-medium text-primary-foreground'
               : 'hover:bg-muted',
           )}
         >
@@ -170,8 +170,8 @@ const DurationPicker = React.forwardRef<HTMLInputElement, DurationPickerProps>(
           className={cn('cursor-pointer', className)}
           {...props}
         />
-        <DialogContent className="sm:max-w-sm w-80 p-0 gap-0">
-          <DialogHeader className="text-center sm:text-center bg-muted border-b py-3">
+        <DialogContent className="w-80 gap-0 p-0 sm:max-w-sm">
+          <DialogHeader className="border-b bg-muted py-3 text-center sm:text-center">
             <DialogTitle className="text-4xl font-semibold">
               {draft}
             </DialogTitle>
@@ -194,7 +194,7 @@ const DurationPicker = React.forwardRef<HTMLInputElement, DurationPickerProps>(
               testId="minute-wheel"
             />
           </div>
-          <DialogFooter className="flex-row justify-end border-t gap-2 py-3 px-6">
+          <DialogFooter className="flex-row justify-end gap-2 border-t px-6 py-3">
             <Button type="button" variant="ghost" onClick={handleClear}>
               {t('clear')}
             </Button>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'inline-block h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'inline-block h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className,
         )}
         ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -9,7 +9,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const labelVariants = cva(
-  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+  'text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
 )
 
 const Label = React.forwardRef<

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -60,7 +60,7 @@ const MenubarTrigger = React.forwardRef<
   <MenubarPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+      'flex cursor-default items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none select-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
       className,
     )}
     {...props}
@@ -77,14 +77,14 @@ const MenubarSubTrigger = React.forwardRef<
   <MenubarPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+      'flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
       inset && 'pl-8',
       className,
     )}
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="ml-auto size-4" />
   </MenubarPrimitive.SubTrigger>
 ))
 MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
@@ -96,7 +96,7 @@ const MenubarSubContent = React.forwardRef<
   <MenubarPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
       className,
     )}
     {...props}
@@ -119,7 +119,7 @@ const MenubarContent = React.forwardRef<
         alignOffset={alignOffset}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'z-50 min-w-48 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           className,
         )}
         {...props}
@@ -138,7 +138,7 @@ const MenubarItem = React.forwardRef<
   <MenubarPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       className,
     )}
@@ -154,15 +154,15 @@ const MenubarCheckboxItem = React.forwardRef<
   <MenubarPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <MenubarPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-4" />
       </MenubarPrimitive.ItemIndicator>
     </span>
     {children}
@@ -177,14 +177,14 @@ const MenubarRadioItem = React.forwardRef<
   <MenubarPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className,
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <MenubarPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="size-2 fill-current" />
       </MenubarPrimitive.ItemIndicator>
     </span>
     {children}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -59,7 +59,7 @@ const NavigationMenuTrigger = React.forwardRef<
   >
     {children}{' '}
     <ChevronDown
-      className="relative top-[1px] ml-1 h-4 w-4 transition duration-200 group-data-[state=open]:rotate-180"
+      className="relative top-px ml-1 size-4 transition duration-200 group-data-[state=open]:rotate-180"
       aria-hidden
     />
   </NavigationMenuPrimitive.Trigger>
@@ -73,7 +73,7 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      'left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-out data-[motion^=to-]:fade-in data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto',
+      'top-0 left-0 w-full data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 data-[motion^=from-]:animate-in data-[motion^=from-]:fade-out data-[motion^=to-]:animate-out data-[motion^=to-]:fade-in md:absolute md:w-auto',
       className,
     )}
     {...props}
@@ -87,10 +87,10 @@ const NavigationMenuViewport = React.forwardRef<
   React.ComponentRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
-  <div className={cn('absolute left-0 top-full flex justify-center')}>
+  <div className={cn('absolute top-full left-0 flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
-        'origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]',
+        'relative mt-1.5 h-(--radix-navigation-menu-viewport-height) w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:zoom-in-90 md:w-(--radix-navigation-menu-viewport-width)',
         className,
       )}
       ref={ref}

--- a/src/components/ui/notification-badge.tsx
+++ b/src/components/ui/notification-badge.tsx
@@ -39,7 +39,7 @@ export function NotificationBadge({
   return (
     <div
       className={cn(
-        'absolute -top-1 -right-1 rounded-full flex items-center justify-center text-white font-medium',
+        'absolute -top-1 -right-1 flex items-center justify-center rounded-full font-medium text-white',
         notificationBadgeVariants.variant[variant],
         notificationBadgeVariants.size[size],
         className,
@@ -47,7 +47,7 @@ export function NotificationBadge({
       {...props}
     >
       {showDot ? (
-        <div className="h-1.5 w-1.5 rounded-full bg-white" />
+        <div className="size-1.5 rounded-full bg-white" />
       ) : (
         <span>{count && count > 9 ? '9+' : count}</span>
       )}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -20,7 +20,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         className,
       )}
       {...props}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -19,7 +19,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="size-full flex-1 bg-primary transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -30,13 +30,13 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        'aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        'aspect-square size-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}
       {...props}
     >
       <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+        <Circle className="size-2.5 fill-current text-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -15,7 +15,7 @@ const ScrollArea = React.forwardRef<
     className={cn('relative overflow-hidden', className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="size-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
@@ -32,11 +32,11 @@ const ScrollBar = React.forwardRef<
     ref={ref}
     orientation={orientation}
     className={cn(
-      'flex touch-none select-none transition-colors',
+      'flex touch-none transition-colors select-none',
       orientation === 'vertical' &&
-        'h-full w-2.5 border-l border-l-transparent p-[1px]',
+        'h-full w-2.5 border-l border-l-transparent p-px',
       orientation === 'horizontal' &&
-        'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+        'h-2.5 flex-col border-t border-t-transparent p-px',
       className,
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -21,14 +21,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="size-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -46,7 +46,7 @@ const SelectScrollUpButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="size-4" />
   </SelectPrimitive.ScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
@@ -63,7 +63,7 @@ const SelectScrollDownButton = React.forwardRef<
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="size-4" />
   </SelectPrimitive.ScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
@@ -77,7 +77,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className,
@@ -90,7 +90,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           'p-1',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+            'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)',
         )}
       >
         {children}
@@ -107,7 +107,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    className={cn('py-1.5 pr-2 pl-8 text-sm font-semibold', className)}
     {...props}
   />
 ))
@@ -120,14 +120,14 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-none select-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
       className,
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
 

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -20,7 +20,7 @@ const Separator = React.forwardRef<
       orientation={orientation}
       className={cn(
         'shrink-0 bg-border',
-        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
         className,
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -23,7 +23,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
@@ -33,7 +33,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500',
   {
     variants: {
       side: {
@@ -72,9 +72,9 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close
         data-testid="sheet-close-button"
-        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
+        className="absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none disabled:pointer-events-none data-[state=open]:bg-secondary"
       >
-        <X className="h-4 w-4" />
+        <X className="size-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -151,7 +151,7 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              'group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
+              'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
               className,
             )}
             ref={ref}
@@ -216,7 +216,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
-            <div className="flex h-full w-full flex-col">{children}</div>
+            <div className="flex size-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>
       )
@@ -238,7 +238,7 @@ const Sidebar = React.forwardRef<
             'group-data-[collapsible=offcanvas]:w-0',
             'group-data-[side=right]:rotate-180',
             variant === 'floating' || variant === 'inset'
-              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
+              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]'
               : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
           )}
         />
@@ -246,11 +246,11 @@ const Sidebar = React.forwardRef<
           className={cn(
             'fixed inset-y-0 z-10 hidden h-svh w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex',
             side === 'left'
-              ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
-              : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+              ? 'left-0 group-data-[collapsible=offcanvas]:-left-(--sidebar-width)'
+              : 'right-0 group-data-[collapsible=offcanvas]:-right-(--sidebar-width)',
             // Adjust the padding for floating and inset variants.
             variant === 'floating' || variant === 'inset'
-              ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
+              ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
               : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l',
             className,
           )}
@@ -258,7 +258,7 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             {children}
           </div>
@@ -281,7 +281,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn('h-7 w-7', className)}
+      className={cn('size-7', className)}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()
@@ -310,8 +310,8 @@ const SidebarRail = React.forwardRef<
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
-        '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
+        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-0.5 hover:after:bg-sidebar-border sm:flex',
+        'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
         '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
         'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',
         '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
@@ -333,7 +333,7 @@ const SidebarInset = React.forwardRef<
       ref={ref}
       className={cn(
         'relative flex min-h-svh flex-1 flex-col bg-background',
-        'peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
+        'peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2',
         className,
       )}
       {...props}
@@ -449,7 +449,7 @@ const SidebarGroupLabel = React.forwardRef<
       ref={ref}
       data-sidebar="group-label"
       className={cn(
-        'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring transition-[margin,opa] duration-200 ease-linear outline-none focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
@@ -470,7 +470,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring transition-transform outline-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:md:hidden',
         'group-data-[collapsible=icon]:hidden',
@@ -522,7 +522,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring transition-[width,height,padding] outline-none group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -533,7 +533,7 @@ const sidebarMenuButtonVariants = cva(
       size: {
         default: 'h-8 text-sm',
         sm: 'h-7 text-xs',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:!p-0',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {
@@ -616,7 +616,7 @@ const SidebarMenuAction = React.forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
+        'absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring transition-transform outline-none peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:md:hidden',
         'peer-data-[size=sm]/menu-button:top-1',
@@ -624,7 +624,7 @@ const SidebarMenuAction = React.forwardRef<
         'peer-data-[size=lg]/menu-button:top-2.5',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
-          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0',
         className,
       )}
       {...props}
@@ -641,7 +641,7 @@ const SidebarMenuBadge = React.forwardRef<
     ref={ref}
     data-sidebar="menu-badge"
     className={cn(
-      'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground',
+      'pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none',
       'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
       'peer-data-[size=sm]/menu-button:top-1',
       'peer-data-[size=default]/menu-button:top-1.5',
@@ -733,7 +733,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-none hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -13,7 +13,7 @@ const Slider = React.forwardRef<
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
-      'relative flex w-full touch-none select-none items-center',
+      'relative flex w-full touch-none items-center select-none',
       className,
     )}
     {...props}
@@ -21,7 +21,7 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="block size-5 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ))
 Slider.displayName = SliderPrimitive.Root.displayName

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -12,7 +12,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
       className,
     )}
     {...props}
@@ -20,7 +20,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
+        'pointer-events-none block size-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0',
       )}
     />
   </SwitchPrimitives.Root>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -15,7 +15,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center rounded-md bg-muted p-1 text-muted-foreground overflow-x-auto justify-start md:justify-center',
+      'inline-flex h-10 items-center justify-start overflow-x-auto rounded-md bg-muted p-1 text-muted-foreground md:justify-center',
       className,
     )}
     {...props}
@@ -30,7 +30,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium whitespace-nowrap ring-offset-background transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}
@@ -45,7 +45,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'mt-2 ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none',
       className,
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'flex min-h-20 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className,
       )}
       ref={ref}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -18,7 +18,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 z-100 flex max-h-screen w-full flex-col-reverse p-4 sm:top-auto sm:right-0 sm:bottom-0 sm:flex-col md:max-w-105',
       className,
     )}
     {...props}
@@ -27,13 +27,13 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName
 
 const toastVariants = cva(
-  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
+  'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[state=closed]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:animate-in data-[state=open]:slide-in-from-top-full data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=end]:animate-out data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:sm:slide-in-from-bottom-full',
   {
     variants: {
       variant: {
         default: 'border bg-background text-foreground',
         destructive:
-          'destructive group border-destructive bg-destructive text-destructive-foreground',
+          'group border-destructive bg-destructive text-destructive-foreground',
       },
     },
     defaultVariants: {
@@ -64,7 +64,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors group-[.destructive]:border-muted/40 hover:bg-secondary group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none group-[.destructive]:focus:ring-destructive disabled:pointer-events-none disabled:opacity-50',
       className,
     )}
     {...props}
@@ -79,13 +79,13 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      'absolute top-2 right-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-red-300 hover:text-foreground group-[.destructive]:hover:text-red-50 focus:opacity-100 focus:ring-2 focus:outline-none group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
       className,
     )}
     toast-close=""
     {...props}
   >
-    <X className="h-4 w-4" />
+    <X className="size-4" />
   </ToastPrimitives.Close>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -21,7 +21,7 @@ const TooltipContent = React.forwardRef<
     side={side}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 animate-in overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
       className,
     )}
     {...props}

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -83,9 +83,9 @@ export default function UserMenu({
                 data-testid="user-menu-btn"
                 variant={variant}
                 size={size}
-                className={`rounded-md hover:bg-green-600 hover:text-white transition-colors ${className}`}
+                className={`rounded-md transition-colors hover:bg-green-600 hover:text-white ${className}`}
               >
-                <Menu className="h-6 w-6" aria-hidden />
+                <Menu className="size-6" aria-hidden />
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
@@ -96,7 +96,7 @@ export default function UserMenu({
         <DropdownMenuContent className="w-56" align="end" forceMount>
           <DropdownMenuLabel className="font-normal">
             <div className="flex flex-col space-y-1">
-              <p className="text-sm font-medium leading-none">{displayName}</p>
+              <p className="text-sm leading-none font-medium">{displayName}</p>
               <p className="text-xs leading-none text-muted-foreground">
                 {user?.email}
               </p>
@@ -105,31 +105,31 @@ export default function UserMenu({
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
             <Link href="/preferences" data-testid="preferences">
-              <Settings className="mr-2 h-4 w-4" />
+              <Settings className="mr-2 size-4" />
               {t('settings.preferences')}
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link href="/company" data-testid="company">
-              <Building2 className="mr-2 h-4 w-4" />
+              <Building2 className="mr-2 size-4" />
               <span className="flex flex-grow">{t('settings.company')}</span>
               {!hasValidSubscription && <ProBadge className="ml-2" />}
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link href="/security" data-testid="security">
-              <Shield className="mr-2 h-4 w-4" />
+              <Shield className="mr-2 size-4" />
               {t('settings.security')}
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link href="/team" data-testid="team">
-              <Users className="mr-2 h-4 w-4" />
+              <Users className="mr-2 size-4" />
               <span className="flex flex-grow">{t('settings.manageTeam')}</span>
               {hasPendingInvitations && (
                 <Badge
                   variant="destructive"
-                  className="ml-2 h-5 min-w-[20px] px-0 text-xs justify-center"
+                  className="ml-2 h-5 min-w-5 justify-center px-0 text-xs"
                 >
                   {invitations.length > 9 ? '9+' : invitations.length}
                 </Badge>
@@ -138,13 +138,13 @@ export default function UserMenu({
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link href="/subscription" data-testid="subscription">
-              <CreditCard className="mr-2 h-4 w-4" />
+              <CreditCard className="mr-2 size-4" />
               {t('settings.manageSubscription')}
             </Link>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onClick={handleSignOut} data-testid="sign-out-btn">
-            <LogOut className="mr-2 h-4 w-4" />
+            <LogOut className="mr-2 size-4" />
             {t('tracker.headerSignOutTooltip')}
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/messages/de/stats.json
+++ b/src/messages/de/stats.json
@@ -17,5 +17,9 @@
   "summaryOvertime": "Überstunden",
   "summarySpecialEntries": "Sondereinträge",
   "noData": "Keine Einträge in diesem Zeitraum",
-  "sectionProjects": "Stunden nach Projekt"
+  "sectionProjects": "Stunden nach Projekt",
+  "periodCustom": "Benutzerdefiniert",
+  "startDate": "Start",
+  "endDate": "Ende",
+  "rangeError": "Der ausgewählte Zeitraum darf maximal 365 Tage umfassen und das Startdatum muss vor dem Enddatum liegen."
 }

--- a/src/messages/en/stats.json
+++ b/src/messages/en/stats.json
@@ -17,5 +17,9 @@
   "summaryOvertime": "Overtime",
   "summarySpecialEntries": "Special entries",
   "noData": "No entries in this period",
-  "sectionProjects": "Hours by project"
+  "sectionProjects": "Hours by project",
+  "periodCustom": "Custom",
+  "startDate": "Start",
+  "endDate": "End",
+  "rangeError": "The selected range cannot exceed 365 days and the start must be before the end."
 }

--- a/src/messages/es/stats.json
+++ b/src/messages/es/stats.json
@@ -17,5 +17,9 @@
   "summaryOvertime": "Horas extra",
   "summarySpecialEntries": "Entradas especiales",
   "noData": "No hay entradas en este período",
-  "sectionProjects": "Horas por proyecto"
+  "sectionProjects": "Horas por proyecto",
+  "periodCustom": "Personalizado",
+  "startDate": "Inicio",
+  "endDate": "Fin",
+  "rangeError": "El rango seleccionado no puede superar 365 días y la fecha de inicio debe ser anterior a la de fin."
 }


### PR DESCRIPTION
## Description

This PR adds a custom date range selector to the statistics view, letting users choose a range up to 365 days. It also includes the Tailwind CSS class-order fixes across the app after enabling the `tailwindcss` ESLint plugin.

## Breaking Changes

None

## Related Issues

Fixes #
Closes #

## Testing

- [ ] Unit tests added/updated and passing
- [ ] E2E tests added/updated and passing (if applicable)
- [ ] Manual testing completed

## Checklist

- [ ] Code properly formatted (`npm run format`)
- [ ] Linting passes (`npm run lint`)
- [ ] Documentation updated (if applicable)
- [ ] New text strings internationalized (if applicable)
- [ ] Firestore security rules reviewed (if applicable)
- [ ] All CI checks passing
